### PR TITLE
chore: make @mdn/engineering default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,7 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
+* @mdn/engineering
+
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering


### PR DESCRIPTION
Self explanatory