### PR TITLE
feat: add get-doc tool

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,15 +11,30 @@ app.post("/mcp", handleRequest);
 
 const PORT = Number.parseInt(process.env.PORT || "3002");
 
-/** @param {number} port */
-export default function listen(port) {
-  return app.listen(port, () => {
-    console.log(`MDN MCP server running on http://localhost:${port}/mcp`);
+/** @param {number} requestedPort */
+export default async function listen(requestedPort) {
+  const listener = app.listen(requestedPort);
+  await new Promise((resolve) => {
+    listener.on("listening", resolve);
   });
+  const address = listener.address();
+
+  /* node:coverage disable */
+  if (typeof address === "string" || !address) {
+    throw new Error("server isn't listening on port");
+  }
+  /* node:coverage enable */
+
+  const { port } = address;
+  console.log(`MDN MCP server running on http://localhost:${port}/mcp`);
+  return {
+    listener,
+    port,
+  };
 }
 
 /* node:coverage disable */
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
-  listen(PORT);
+  await listen(PORT);
 }
 /* node:coverage enable */

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 
 import express from "express";
 
+import "./tools/get-doc.js";
 import handleRequest from "./transport.js";
 
 const app = express();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1981,7 +1981,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
       "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2102,7 +2101,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2347,7 +2345,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2736,7 +2733,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3780,7 +3776,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4356,7 +4351,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7088,7 +7082,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7102,7 +7095,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8445,7 +8437,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8939,7 +8930,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.2",
+        "undici": "^7.16.0",
         "zod": "^3.25.76"
       },
       "engines": {
@@ -7290,6 +7291,16 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "MPL-2.0",
       "dependencies": {
+        "@lit-labs/ssr": "^3.3.1",
+        "@mdn/fred": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.20.2",
         "express": "^5.1.0"
       },
@@ -37,6 +39,23 @@
         "node": ">=22"
       }
     },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
@@ -45,6 +64,156 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.19.1.tgz",
+      "integrity": "sha512-q6NenYkEy2fn9+JyjIxMWcNjzTL/IhwqfzOut1/G3PrIFkrbl4AL7Wkse5tLrQUUyqGoAKU5+Pi5jnnXxH5HGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
+      "integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+      "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+      "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
+      "integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -284,6 +453,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@fluent/bundle": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@fluent/bundle/-/bundle-0.19.1.tgz",
+      "integrity": "sha512-SWJLZrPamDPsJlFFOW1nkgN0j0rbPbmSdmK0XAoXlyqKieLtMVl4vzng3aR5pwKoUx0scug8+YY2oct3fdfy9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -336,6 +515,18 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -363,6 +554,207 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.3.0.tgz",
+      "integrity": "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
+      "integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.3.tgz",
+      "integrity": "sha512-yenN5SqAxAPv/qMnpWW0AT7l+SxVrgG+u0tNsRQWqbrz66HIl8DnEbBObvy21J5K7+I1v7gsAnlE2VQ5yYVSeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-3.3.1.tgz",
+      "integrity": "sha512-JlF1PempxvzrGEpRFrF+Ki0MHzR3HA51SK8Zv0cFpW9p0bPW4k0FeCwrElCu371UEpXF7RcaE2wgYaE1az0XKg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit-labs/ssr-dom-shim": "^1.3.0",
+        "@lit/reactive-element": "^2.0.4",
+        "@parse5/tools": "^0.3.0",
+        "@types/node": "^16.0.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^3.1.2",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.7.tgz",
+      "integrity": "sha512-VvqhY/iif3FHrlhkzEPsuX/7h/NqnfxLwVf0p8ghNIlKegRyRqgeaJevZ57s/u/LiFyKgqksRP5n+LmNvpxN+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit": "^3.1.2",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
+      "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit-labs/ssr/node_modules/@types/node": {
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "license": "MIT"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
+      "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0"
+      }
+    },
+    "node_modules/@lit/task": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lit/task/-/task-1.0.3.tgz",
+      "integrity": "sha512-1gJGJl8WON+2j0y9xfcD+XsS1rvcy3XDgsIhcdUW++yTR8ESjZW6o7dn8M8a4SZM8NnJe6ynS2cKWwsbfLOurg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
+    "node_modules/@mdn/fred": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@mdn/fred/-/fred-1.8.1.tgz",
+      "integrity": "sha512-Yt20De72HMB/SR2JM1uRsbBMuVh4bIev0Grszw7mPbeDNlk6V6XNuesMU872QJr41Jwr92tRon3tLrqQ3PV8FQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-javascript": "^6.2.3",
+        "@codemirror/lang-wast": "^6.0.2",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/theme-one-dark": "^6.1.2",
+        "@fluent/bundle": "^0.19.0",
+        "@lit-labs/ssr": "^3.3.1",
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit/task": "^1.0.3",
+        "@mdn/rari": "0.2.0",
+        "@mdn/watify": "^1.1.5",
+        "@mozilla/glean": "^5.0.6",
+        "codemirror": "^6.0.1",
+        "compression": "^1.8.1",
+        "concurrently": "^9.2.1",
+        "cookie-parser": "^1.4.7",
+        "express": "^5.0.1",
+        "fdir": "^6.5.0",
+        "he": "^1.2.0",
+        "http-proxy-middleware": "^3.0.3",
+        "insane": "^2.6.2",
+        "lit": "^3.3.1",
+        "lit-html": "^3.3.1",
+        "open-editor": "^5.1.0",
+        "prism-svelte": "^0.5.0",
+        "prismjs": "^1.29.0",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "fred-server": "scripts/server.js",
+        "fred-ssr": "build/ssr.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@mdn/rari": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mdn/rari/-/rari-0.2.0.tgz",
+      "integrity": "sha512-SXJQxEp5IuXBqxMlRIwzMjI4c5nKCHTOEnPt3QrTWJyyT3pIDlZe1xeAog4Q1HOdAbk34dRUKNwSYT3nawDo2A==",
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^7.0.2",
+        "json-schema-to-typescript": "^15.0.0",
+        "proxy-from-env": "^1.1.0",
+        "tar": "^7.4.3"
+      },
+      "bin": {
+        "rari": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@mdn/watify": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@mdn/watify/-/watify-1.1.5.tgz",
+      "integrity": "sha512-lCiovK+LSowttMZ9ZRXMtf/qH1pggeRwi3Dy7gz415ZcVMXrs09ubSda236vr+QPQPwchxtA5JWV4cypGcyuwA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.17.2",
@@ -499,6 +891,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mozilla/glean": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-5.0.6.tgz",
+      "integrity": "sha512-Oz4M+pxHmTcy82iCCmcARjEwwDCsMZCwidRhdZU0pYueEFJgDc5S+u48Y68SxEsExFAthuhzE2H4BcvwsRhYJg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "fflate": "^0.8.0",
+        "tslib": "^2.3.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "glean": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=12.20.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -535,6 +945,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@parse5/tools": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@parse5/tools/-/tools-0.3.0.tgz",
+      "integrity": "sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -1394,11 +1813,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/base62": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
       "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1495,11 +1932,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1507,6 +1952,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -1520,7 +1971,6 @@
       "version": "22.18.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
       "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1570,6 +2020,22 @@
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -1893,6 +2359,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1913,7 +2388,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1923,7 +2397,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1983,7 +2456,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -2121,6 +2593,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assignment": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assignment/-/assignment-2.0.0.tgz",
+      "integrity": "sha512-naMULXjtgCs9SVUEtyvJNt68aF18em7/W+dhbR59kbz9cXWPEvUkCun2tqlgqRPSqZaKPpqLc5ZnwL8jVmJRvw=="
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2212,7 +2689,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2255,6 +2731,21 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/builtin-modules": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
@@ -2272,7 +2763,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "run-applescript": "^7.0.0"
@@ -2376,7 +2866,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2432,6 +2921,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -2490,7 +2988,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2528,11 +3025,25 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2545,7 +3056,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -2568,6 +3078,60 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2579,7 +3143,6 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
       "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
@@ -2604,7 +3167,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2645,6 +3207,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -2689,6 +3270,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2707,7 +3294,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2795,7 +3381,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
       "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -2812,7 +3397,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
       "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2843,7 +3427,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2940,7 +3523,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2952,11 +3534,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
       "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2964,6 +3554,30 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-editor": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-1.3.0.tgz",
+      "integrity": "sha512-EqiD/j01PooUbeWk+etUo2TWoocjoxMfGNYpS9e47glIJ5r8WepycIki+LCbonFbPdwlqY5ETeSTAJVMih4z4w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -3116,7 +3730,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3648,6 +4261,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -3667,6 +4286,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/express": {
@@ -3724,6 +4385,26 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3785,11 +4466,36 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3809,6 +4515,27 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3826,7 +4553,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3903,6 +4629,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3923,7 +4669,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -4019,7 +4764,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4070,6 +4814,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4169,7 +4928,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -4196,7 +4954,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4271,6 +5028,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -4311,6 +5077,59 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -4387,6 +5206,25 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/insane": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/insane/-/insane-2.6.2.tgz",
+      "integrity": "sha512-BqEL1CJsjJi+/C/zKZxv31zs3r6zkLH5Nz1WMFb7UBX2KHY2yXDpbFTSEmNHzomBbGDysIfkTX55A0mQZ2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "assignment": "2.0.0",
+        "he": "0.5.0"
+      }
+    },
+    "node_modules/insane/node_modules/he": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
+      "integrity": "sha512-DoufbNNOFzwRPy8uecq+j+VCPQ+JyDelHTmSgygrA5TsR8Cbw4Qcir5sGtWiusB4BdT89nmlaVDhSJOqC/33vw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4580,7 +5418,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -4596,7 +5433,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4622,7 +5458,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4652,7 +5487,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4665,7 +5499,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -4710,7 +5543,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4731,6 +5563,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -4787,6 +5640,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -4836,6 +5701,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -4888,7 +5765,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
       "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -4924,7 +5800,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4962,6 +5837,29 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5176,6 +6074,52 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/line-column-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/line-column-path/-/line-column-path-3.0.0.tgz",
+      "integrity": "sha512-Atocnm7Wr9nuvAn97yEPQa3pcQI5eLQGBz+m6iTb+CVw+IOzYB9MrYK7jI7BfC9ISnT4Fu0eiwhAScV//rp4Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
+      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
+      "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
+      "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5191,6 +6135,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5273,7 +6223,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5287,7 +6236,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5334,10 +6282,30 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -5367,7 +6335,6 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5387,7 +6354,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -5482,6 +6448,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -5608,6 +6602,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5621,13 +6624,30 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
       "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
         "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-editor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/open-editor/-/open-editor-5.1.0.tgz",
+      "integrity": "sha512-KkNqM6FdoegD6WhY2YXmWcovOux45NV+zBped2+G3+V74zkDPkIl4cqh6hte2zNDojtwO2nBOV8U+sgziWfPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-editor": "^1.1.0",
+        "execa": "^9.3.0",
+        "line-column-path": "^3.0.0",
+        "open": "^10.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -5727,12 +6747,36 @@
         "parse-statements": "1.0.11"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-statements": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
       "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -5786,6 +6830,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5797,7 +6847,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5849,7 +6898,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5861,11 +6909,31 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prism-svelte": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/prism-svelte/-/prism-svelte-0.5.0.tgz",
+      "integrity": "sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==",
+      "license": "MIT"
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5884,12 +6952,28 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6196,11 +7280,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/reserved-identifiers": {
       "version": "1.0.0",
@@ -6287,7 +7376,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6324,7 +7412,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -6624,7 +7711,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6705,6 +7791,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -6729,6 +7827,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spawn-rx": {
@@ -6794,7 +7911,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6868,7 +7984,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6885,6 +8000,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -6913,11 +8040,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6954,7 +8086,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6964,11 +8095,42 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7017,7 +8179,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -7120,7 +8281,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -7134,6 +8294,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -7306,8 +8478,19 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -7403,6 +8586,19 @@
         }
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -7419,11 +8615,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7547,7 +8748,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7593,7 +8793,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
       "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0"
@@ -7609,17 +8808,24 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7638,10 +8844,19 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {
@@ -7662,6 +8877,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@lit-labs/ssr": "^3.3.1",
         "@mdn/fred": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.20.2",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "turndown": "^7.2.2",
+        "turndown-plugin-gfm": "^1.0.2"
       },
       "devDependencies": {
         "@eslint/compat": "^1.4.0",
@@ -20,6 +22,7 @@
         "@modelcontextprotocol/inspector": "^0.17.2",
         "@types/express": "^5.0.4",
         "@types/node": "^22.18.12",
+        "@types/turndown": "^5.0.6",
         "concurrently": "^9.2.1",
         "eslint": "^9.38.0",
         "eslint-config-prettier": "^10.1.8",
@@ -755,6 +758,12 @@
       "resolved": "https://registry.npmjs.org/@mdn/watify/-/watify-1.1.5.tgz",
       "integrity": "sha512-lCiovK+LSowttMZ9ZRXMtf/qH1pggeRwi3Dy7gz415ZcVMXrs09ubSda236vr+QPQPwchxtA5JWV4cypGcyuwA==",
       "license": "MPL-2.0"
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.17.2",
@@ -1972,6 +1981,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.12.tgz",
       "integrity": "sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2027,6 +2037,13 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -2085,6 +2102,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2329,6 +2347,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2717,6 +2736,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3760,6 +3780,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4335,6 +4356,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7066,6 +7088,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7079,6 +7102,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8283,6 +8307,21 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/turndown": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8406,6 +8445,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8899,6 +8939,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "nodemon": "^3.1.10",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.46.2"
+        "typescript-eslint": "^8.46.2",
+        "zod": "^3.25.76"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:watch": "node --test --watch test/**/*.test.js"
   },
   "dependencies": {
+    "@lit-labs/ssr": "^3.3.1",
+    "@mdn/fred": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.20.2",
     "express": "^5.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:server": "nodemon index.js",
     "dev:inspector": "mcp-inspector --config mcp.json",
     "tsc": "tsc",
-    "test": "node --test --experimental-test-coverage --test-coverage-lines 100 --test-coverage-exclude test/**/* --test-coverage-exclude test/**/*.test.js test/**/*.test.js",
+    "test": "node --test --experimental-test-coverage --test-coverage-lines 100 --test-coverage-exclude 'test/**/*' 'test/**/*.test.js'",
     "test:watch": "node --test --watch test/**/*.test.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "nodemon": "^3.1.10",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.46.2"
+    "typescript-eslint": "^8.46.2",
+    "zod": "^3.25.76"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "@lit-labs/ssr": "^3.3.1",
     "@mdn/fred": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.20.2",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "turndown": "^7.2.2",
+    "turndown-plugin-gfm": "^1.0.2"
   },
   "devDependencies": {
     "@eslint/compat": "^1.4.0",
@@ -26,6 +28,7 @@
     "@modelcontextprotocol/inspector": "^0.17.2",
     "@types/express": "^5.0.4",
     "@types/node": "^22.18.12",
+    "@types/turndown": "^5.0.6",
     "concurrently": "^9.2.1",
     "eslint": "^9.38.0",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.2",
+    "undici": "^7.16.0",
     "zod": "^3.25.76"
   },
   "engines": {

--- a/server.js
+++ b/server.js
@@ -1,8 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-const server = new McpServer({
-  name: "mdn",
-  version: "0.0.1",
-});
+const server = new McpServer(
+  {
+    name: "mdn",
+    version: "0.0.1",
+  },
+  {
+    instructions: `Available tools:
+
+\`get-doc\`: Retrieve complete MDN documentation as formatted markdown. Use this when users need detailed information, code examples, specifications, or comprehensive explanations. Ideal for learning concepts in-depth, understanding API signatures, or when teaching web development topics.`,
+  },
+);
 
 export default server;

--- a/test/fixtures/headers.json
+++ b/test/fixtures/headers.json
@@ -1,0 +1,173 @@
+{
+  "doc": {
+    "body": [
+      {
+        "type": "prose",
+        "value": {
+          "id": null,
+          "title": null,
+          "isH3": false,
+          "content": " \n<div class=\"notecard note\"><p><strong>Note:</strong> This feature is available in <a href=\"/en-US/docs/Web/API/Web_Workers_API\">Web Workers</a>.</p></div>\n<p>The <strong><code>Headers</code></strong> interface of the <a href=\"/en-US/docs/Web/API/Fetch_API\">Fetch API</a> allows you to perform various actions on <a href=\"/en-US/docs/Web/HTTP/Reference/Headers\">HTTP request and response headers</a>. These actions include retrieving, setting, adding to, and removing headers from the list of the request's headers.</p>\n<p>You can retrieve a <code>Headers</code> object via the <a href=\"/en-US/docs/Web/API/Request/headers\"><code>Request.headers</code></a> and <a href=\"/en-US/docs/Web/API/Response/headers\"><code>Response.headers</code></a> properties, and create a new <code>Headers</code> object using the <a href=\"/en-US/docs/Web/API/Headers/Headers\" title=\"Headers()\"><code>Headers()</code></a> constructor. Compared to using plain objects, using <code>Headers</code> objects to send requests provides some additional input sanitization. For example, it normalizes header names to lowercase, strips leading and trailing whitespace from header values, and prevents certain headers from being set.</p>\n<div class=\"notecard note\">\n<p><strong>Note:</strong>\nYou can find out more about the available headers by reading our <a href=\"/en-US/docs/Web/HTTP/Reference/Headers\">HTTP headers</a> reference.</p>\n</div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "description",
+          "title": "Description",
+          "isH3": false,
+          "content": "<p>A <code>Headers</code> object has an associated header list, which is initially empty and consists of zero or more name and value pairs. You can add to this using methods like <a href=\"/en-US/docs/Web/API/Headers/append\" title=\"append()\"><code>append()</code></a> (see <a href=\"#examples\">Examples</a>.) In all methods of this interface, header names are matched by case-insensitive byte sequence.</p>\n<p>An object implementing <code>Headers</code> can directly be used in a <a href=\"/en-US/docs/Web/JavaScript/Reference/Statements/for...of\"><code>for...of</code></a> structure, instead of <a href=\"/en-US/docs/Web/API/Headers/entries\" title=\"entries()\"><code>entries()</code></a>: <code>for (const p of myHeaders)</code> is equivalent to <code>for (const p of myHeaders.entries())</code>.</p>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "modification_restrictions",
+          "title": "Modification restrictions",
+          "isH3": true,
+          "content": "<p>Some <code>Headers</code> objects have restrictions on whether the <a href=\"/en-US/docs/Web/API/Headers/set\" title=\"set()\"><code>set()</code></a>, <a href=\"/en-US/docs/Web/API/Headers/delete\" title=\"delete()\"><code>delete()</code></a>, and <a href=\"/en-US/docs/Web/API/Headers/append\" title=\"append()\"><code>append()</code></a> methods can mutate the header. The modification restrictions are set depending on how the <code>Headers</code> object is created.</p>\n<ul>\n<li>For headers created with <a href=\"/en-US/docs/Web/API/Headers/Headers\" title=\"Headers()\"><code>Headers()</code></a> constructor, there are no modification restrictions.</li>\n<li>For headers of <a href=\"/en-US/docs/Web/API/Request\"><code>Request</code></a> objects:\n<ul>\n<li>If the request's <a href=\"/en-US/docs/Web/API/Request/mode\" title=\"mode\"><code>mode</code></a> is <code>no-cors</code>, you can modify any <a href=\"/en-US/docs/Glossary/CORS-safelisted_request_header\">CORS-safelisted request header</a> name/value.</li>\n<li>Otherwise, you can modify any <a href=\"/en-US/docs/Glossary/Forbidden_request_header\">non-forbidden request header</a> name/value.</li>\n</ul>\n</li>\n<li>For headers of <a href=\"/en-US/docs/Web/API/Response\"><code>Response</code></a> objects:\n<ul>\n<li>If the response is created using <a href=\"/en-US/docs/Web/API/Response/error_static\" title=\"Response.error()\"><code>Response.error()</code></a> or <a href=\"/en-US/docs/Web/API/Response/redirect_static\" title=\"Response.redirect()\"><code>Response.redirect()</code></a>, or received from a <a href=\"/en-US/docs/Web/API/Window/fetch\" title=\"fetch()\"><code>fetch()</code></a> call, the headers are immutable and cannot be modified.</li>\n<li>Otherwise, if the response is created using <a href=\"/en-US/docs/Web/API/Response/Response\" title=\"Response()\"><code>Response()</code></a> or <a href=\"/en-US/docs/Web/API/Response/json_static\" title=\"Response.json()\"><code>Response.json()</code></a>, you can modify any <a href=\"/en-US/docs/Glossary/Forbidden_response_header_name\">non-forbidden response header</a> name/value.</li>\n</ul>\n</li>\n</ul>\n<p>All of the Headers methods will throw a <a href=\"/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError\"><code>TypeError</code></a> if you try to pass in a reference to a name that isn't a <a href=\"https://fetch.spec.whatwg.org/#concept-header-name\" class=\"external\" target=\"_blank\">valid HTTP Header name</a>. The mutation operations will throw a <code>TypeError</code> if the header is immutable. In any other failure case they fail silently.</p>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "constructor",
+          "title": "Constructor",
+          "isH3": false,
+          "content": "<dl>\n<dt id=\"headers\"><a href=\"/en-US/docs/Web/API/Headers/Headers\" title=\"Headers()\"><code>Headers()</code></a></dt>\n<dd>\n<p>Creates a new <code>Headers</code> object.</p>\n</dd>\n</dl>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "instance_methods",
+          "title": "Instance methods",
+          "isH3": false,
+          "content": "<dl>\n<dt id=\"headers.append\"><a href=\"/en-US/docs/Web/API/Headers/append\"><code>Headers.append()</code></a></dt>\n<dd>\n<p>Appends a new value onto an existing header inside a <code>Headers</code> object, or adds the header if it does not already exist.</p>\n</dd>\n<dt id=\"headers.delete\"><a href=\"/en-US/docs/Web/API/Headers/delete\"><code>Headers.delete()</code></a></dt>\n<dd>\n<p>Deletes a header from a <code>Headers</code> object.</p>\n</dd>\n<dt id=\"headers.entries\"><a href=\"/en-US/docs/Web/API/Headers/entries\"><code>Headers.entries()</code></a></dt>\n<dd>\n<p>Returns an <a href=\"/en-US/docs/Web/JavaScript/Reference/Iteration_protocols\"><code>iterator</code></a> allowing to go through all key/value pairs contained in this object.</p>\n</dd>\n<dt id=\"headers.foreach\"><a href=\"/en-US/docs/Web/API/Headers/forEach\"><code>Headers.forEach()</code></a></dt>\n<dd>\n<p>Executes a provided function once for each key/value pair in this <code>Headers</code> object.</p>\n</dd>\n<dt id=\"headers.get\"><a href=\"/en-US/docs/Web/API/Headers/get\"><code>Headers.get()</code></a></dt>\n<dd>\n<p>Returns a <a href=\"/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\"><code>String</code></a> sequence of all the values of a header within a <code>Headers</code> object with a given name.</p>\n</dd>\n<dt id=\"headers.getsetcookie\"><a href=\"/en-US/docs/Web/API/Headers/getSetCookie\"><code>Headers.getSetCookie()</code></a></dt>\n<dd>\n<p>Returns an array containing the values of all <a href=\"/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie\"><code>Set-Cookie</code></a> headers associated with a response.</p>\n</dd>\n<dt id=\"headers.has\"><a href=\"/en-US/docs/Web/API/Headers/has\"><code>Headers.has()</code></a></dt>\n<dd>\n<p>Returns a boolean stating whether a <code>Headers</code> object contains a certain header.</p>\n</dd>\n<dt id=\"headers.keys\"><a href=\"/en-US/docs/Web/API/Headers/keys\"><code>Headers.keys()</code></a></dt>\n<dd>\n<p>Returns an <a href=\"/en-US/docs/Web/JavaScript/Reference/Iteration_protocols\"><code>iterator</code></a> allowing you to go through all keys of the key/value pairs contained in this object.</p>\n</dd>\n<dt id=\"headers.set\"><a href=\"/en-US/docs/Web/API/Headers/set\"><code>Headers.set()</code></a></dt>\n<dd>\n<p>Sets a new value for an existing header inside a <code>Headers</code> object, or adds the header if it does not already exist.</p>\n</dd>\n<dt id=\"headers.values\"><a href=\"/en-US/docs/Web/API/Headers/values\"><code>Headers.values()</code></a></dt>\n<dd>\n<p>Returns an <a href=\"/en-US/docs/Web/JavaScript/Reference/Iteration_protocols\"><code>iterator</code></a> allowing you to go through all values of the key/value pairs contained in this object.</p>\n</dd>\n</dl>\n<div class=\"notecard note\">\n<p><strong>Note:</strong>\nTo be clear, the difference between <a href=\"/en-US/docs/Web/API/Headers/set\"><code>Headers.set()</code></a> and <a href=\"/en-US/docs/Web/API/Headers/append\"><code>Headers.append()</code></a> is that if the specified header does already exist and does accept multiple values, <a href=\"/en-US/docs/Web/API/Headers/set\"><code>Headers.set()</code></a> will overwrite the existing value with the new one, whereas <a href=\"/en-US/docs/Web/API/Headers/append\"><code>Headers.append()</code></a> will append the new value onto the end of the set of values. See their dedicated pages for example code.</p>\n</div>\n<div class=\"notecard note\">\n<p><strong>Note:</strong>\nWhen Header values are iterated over, they are automatically sorted in lexicographical order, and values from duplicate header names are combined.</p>\n</div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "examples",
+          "title": "Examples",
+          "isH3": false,
+          "content": "<p>In the following snippet, we create a new header using the <code>Headers()</code> constructor, add a new header to it using <code>append()</code>, then return that header value using <code>get()</code>:</p>\n<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">js</span></div><pre class=\"brush: js notranslate\"><code>const myHeaders = new Headers();\n\nmyHeaders.append(\"Content-Type\", \"text/xml\");\nmyHeaders.get(\"Content-Type\"); // should return 'text/xml'\n</code></pre></div>\n<p>The same can be achieved by passing an array of arrays or an object literal to the constructor:</p>\n<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">js</span></div><pre class=\"brush: js notranslate\"><code>let myHeaders = new Headers({\n  \"Content-Type\": \"text/xml\",\n});\n\n// or, using an array of arrays:\nmyHeaders = new Headers([[\"Content-Type\", \"text/xml\"]]);\n\nmyHeaders.get(\"Content-Type\"); // should return 'text/xml'\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "specifications",
+        "value": {
+          "id": "specifications",
+          "title": "Specifications",
+          "isH3": false,
+          "specifications": [
+            {
+              "bcdSpecificationURL": "https://fetch.spec.whatwg.org/#headers-class",
+              "title": "Fetch"
+            }
+          ],
+          "query": "api.Headers"
+        }
+      },
+      {
+        "type": "browser_compatibility",
+        "value": {
+          "id": "browser_compatibility",
+          "title": "Browser compatibility",
+          "isH3": false,
+          "query": "api.Headers"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "see_also",
+          "title": "See also",
+          "isH3": false,
+          "content": "<ul>\n<li><a href=\"/en-US/docs/Web/API/Service_Worker_API\">ServiceWorker API</a></li>\n<li><a href=\"/en-US/docs/Web/HTTP/Guides/CORS\">HTTP access control (CORS)</a></li>\n<li><a href=\"/en-US/docs/Web/HTTP\">HTTP</a></li>\n</ul>"
+        }
+      }
+    ],
+    "isActive": true,
+    "isMarkdown": true,
+    "isTranslated": false,
+    "locale": "en-US",
+    "mdn_url": "/en-US/docs/Web/API/Headers",
+    "modified": "2025-03-13T12:48:23.000Z",
+    "native": "English (US)",
+    "noIndexing": false,
+    "other_translations": [
+      { "locale": "en-US", "title": "Headers", "native": "English (US)" },
+      { "locale": "de", "title": "Headers", "native": "Deutsch" },
+      { "locale": "es", "title": "Headers", "native": "Español" },
+      { "locale": "fr", "title": "Headers", "native": "Français" },
+      { "locale": "ja", "title": "Headers", "native": "日本語" },
+      { "locale": "ko", "title": "Headers", "native": "한국어" },
+      { "locale": "zh-CN", "title": "Headers", "native": "中文 (简体)" }
+    ],
+    "pageTitle": "Headers - Web APIs | MDN",
+    "parents": [
+      { "uri": "/en-US/docs/Web", "title": "Web" },
+      { "uri": "/en-US/docs/Web/API", "title": "Web APIs" },
+      { "uri": "/en-US/docs/Web/API/Headers", "title": "Headers" }
+    ],
+    "popularity": 0.0048434548205698045,
+    "short_title": "Headers",
+    "sidebarHTML": "<ol><li class=\"section\"><a href=\"/en-US/docs/Web/API/Fetch_API\">Fetch API</a></li><li class=\"section\"><em><a href=\"/en-US/docs/Web/API/Headers\" aria-current=\"page\"><code>Headers</code></a></em></li><li><details open=\"\"><summary><span>Constructor</span></summary><ol><li><a href=\"/en-US/docs/Web/API/Headers/Headers\"><code>Headers()</code></a></li></ol></details></li><li><details open=\"\"><summary><span>Instance methods</span></summary><ol><li><a href=\"/en-US/docs/Web/API/Headers/append\"><code>append()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/delete\"><code>delete()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/entries\"><code>entries()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/forEach\"><code>forEach()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/get\"><code>get()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/getSetCookie\"><code>getSetCookie()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/has\"><code>has()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/keys\"><code>keys()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/set\"><code>set()</code></a></li><li><a href=\"/en-US/docs/Web/API/Headers/values\"><code>values()</code></a></li></ol></details></li><li><details open=\"\"><summary><span>Related pages for Fetch API</span></summary><ol><li><a href=\"/en-US/docs/Web/API/Request\"><code>Request</code></a></li><li><a href=\"/en-US/docs/Web/API/RequestInit\"><code>RequestInit</code></a></li><li><a href=\"/en-US/docs/Web/API/Response\"><code>Response</code></a></li><li><a href=\"/en-US/docs/Web/API/Window/fetch\"><code>Window<wbr>.fetch()</code></a></li><li><a href=\"/en-US/docs/Web/API/WorkerGlobalScope/fetch\"><code>WorkerGlobalScope<wbr>.fetch()</code></a></li></ol></details></li><li><details open=\"\"><summary><span>Guides</span></summary><ol><li><a href=\"/en-US/docs/Web/API/Fetch_API/Using_Fetch\">Using the Fetch API</a></li></ol></details></li></ol>",
+    "source": {
+      "folder": "en-us/web/api/headers",
+      "github_url": "https://github.com/mdn/content/blob/main/files/en-us/web/api/headers/index.md",
+      "last_commit_url": "https://github.com/mdn/content/commit/4d929bb0a021c7130d5a71a4bf505bcb8070378d",
+      "filename": "index.md"
+    },
+    "summary": "The Headers interface of the Fetch API allows you to perform various actions on HTTP request and response headers. These actions include retrieving, setting, adding to, and removing headers from the list of the request's headers.",
+    "title": "Headers",
+    "toc": [
+      { "text": "Description", "id": "description" },
+      { "text": "Constructor", "id": "constructor" },
+      { "text": "Instance methods", "id": "instance_methods" },
+      { "text": "Examples", "id": "examples" },
+      { "text": "Specifications", "id": "specifications" },
+      { "text": "Browser compatibility", "id": "browser_compatibility" },
+      { "text": "See also", "id": "see_also" }
+    ],
+    "baseline": {
+      "baseline": "high",
+      "baseline_low_date": "2017-03-27",
+      "baseline_high_date": "2019-09-27",
+      "support": {
+        "chrome": "42",
+        "chrome_android": "42",
+        "edge": "14",
+        "firefox": "39",
+        "firefox_android": "39",
+        "safari": "10.1",
+        "safari_ios": "10.3"
+      },
+      "asterisk": true,
+      "feature": {
+        "status": {
+          "baseline": "high",
+          "baseline_low_date": "2017-03-27",
+          "baseline_high_date": "2019-09-27",
+          "support": {
+            "chrome": "42",
+            "chrome_android": "42",
+            "edge": "14",
+            "firefox": "39",
+            "firefox_android": "39",
+            "safari": "10.1",
+            "safari_ios": "10.3"
+          }
+        },
+        "description_html": "The <code>fetch()</code> method makes asynchronous HTTP requests.",
+        "name": "Fetch"
+      }
+    },
+    "browserCompat": ["api.Headers"],
+    "pageType": "web-api-interface"
+  },
+  "url": "/en-US/docs/Web/API/Headers",
+  "renderer": "Doc"
+}

--- a/test/fixtures/kitchensink.json
+++ b/test/fixtures/kitchensink.json
@@ -1,0 +1,326 @@
+{
+  "doc": {
+    "body": [
+      {
+        "type": "prose",
+        "value": {
+          "id": null,
+          "title": null,
+          "isH3": false,
+          "content": "<div class=\"notecard warning\">\n<p><strong>Warning:</strong>\nDon't delete this page. It's used by <a href=\"https://github.com/mdn/yari\" class=\"external\" target=\"_blank\">mdn/yari</a> for its automation.</p>\n</div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "about_this_page",
+          "title": "About this page",
+          "isH3": false,
+          "content": "<p>The <strong>kitchensink</strong> is a page that <em>attempts</em> to incorporate every possible content element and Yari macro.</p>\n<p>This page attempts to be the complete intersection of every other page. Not in terms of the text but in terms of the styles and macros.\nLet's start with some notes…</p>\n<p>Text that uses the <code>&lt;kbd&gt;</code> tag: <kbd>Shift</kbd></p>\n<div class=\"notecard note\">\n<p><strong>Note:</strong>\nHere's a block indicator note.</p>\n</div>\n<div class=\"notecard warning\">\n<p><strong>Warning:</strong>\nHere's a block indicator warning.</p>\n</div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "prevnext_buttons",
+          "title": "Prev/Next buttons",
+          "isH3": false,
+          "content": "<ul class=\"prev-next\"><li class=\"prev\"><a class=\"button secondary\" href=\"/en-US/docs/Games/Techniques/Control_mechanisms/Desktop_with_mouse_and_keyboard\"><span class=\"button-wrap\"> Previous </span></a></li><li class=\"menu\"><a class=\"button secondary\" href=\"/en-US/docs/Games/Techniques/Control_mechanisms\"><span class=\"button-wrap\"> Overview: Implementing game control mechanisms</span></a></li><li class=\"next\"><a class=\"button secondary\" href=\"/en-US/docs/Games/Techniques/Control_mechanisms/Other\"><span class=\"button-wrap\"> Next  </span></a></li></ul>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "another_one…",
+          "title": "Another one…",
+          "isH3": true,
+          "content": "<ul class=\"prev-next\"><li class=\"prev\"><a class=\"button secondary\" href=\"/en-US/docs/Games/Tutorials/2D_breakout_game_Phaser/Extra_lives\"><span class=\"button-wrap\"> Previous </span></a></li><li class=\"next\"><a class=\"button secondary\" href=\"/en-US/docs/Games/Tutorials/2D_breakout_game_Phaser/Buttons\"><span class=\"button-wrap\"> Next  </span></a></li></ul>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "code_snippets",
+          "title": "Code snippets",
+          "isH3": false,
+          "content": ""
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "plain_text",
+          "title": "Plain text",
+          "isH3": true,
+          "content": "<pre class=\"brush: plain notranslate\">  ___________________________\n&lt; I'm an expert in my field. &gt;\n  ---------------------------\n         \\   ^__^\n          \\  (oo)\\_______\n             (__)\\       )\\/\\\n                 ||----w |\n                 ||     ||\n</pre>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "html",
+          "title": "HTML",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">html</span></div><pre class=\"brush: html notranslate\"><code>&lt;pre&gt;&lt;/pre&gt;\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "javascript",
+          "title": "JavaScript",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">js</span></div><pre class=\"brush: js notranslate\"><code>const f = () =&gt; {\n  return Math.random();\n};\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "css",
+          "title": "CSS",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">css</span></div><pre class=\"brush: css notranslate\"><code>:root {\n  --first-color: #488cff;\n  --second-color: #ffff8c;\n}\n\n#firstParagraph {\n  background-color: var(--first-color);\n  color: var(--second-color);\n}\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "webassembly",
+          "title": "WebAssembly",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">wat</span></div><pre class=\"brush: wat notranslate\"><code>(func (param i32) (param f32) (local f64)\n  local.get 0\n  local.get 1\n  local.get 2)\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "rust",
+          "title": "Rust",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">rust</span></div><pre class=\"brush: rust notranslate\"><code>#[cfg(test)]\nmod tests {\n    #[test]\n    fn it_works() {\n        assert_eq!(2 + 2, 4);\n    }\n}\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "python",
+          "title": "Python",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">python</span></div><pre class=\"brush: python notranslate\"><code>class BookListView(generic.ListView):\n    model = Book\n    # your own name for the list as a template variable\n    context_object_name = 'my_book_list'\n    queryset = Book.objects.filter(title__icontains='war')[:5]\n    template_name = 'books/my_arbitrary_template_name_list.html'\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "interactive_examples",
+          "title": "Interactive examples",
+          "isH3": false,
+          "content": ""
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "try_it",
+          "title": "Try it",
+          "isH3": false,
+          "content": "<interactive-example name=\"HTML Demo: &amp;lt;data&amp;gt;\" height=\"tabbed-shorter\"></interactive-example>\n<div class=\"code-example\"><pre class=\"brush: html interactive-example notranslate\"><code>&lt;p&gt;New Products:&lt;/p&gt;\n&lt;ul&gt;\n  &lt;li&gt;&lt;data value=\"398\"&gt;Mini Ketchup&lt;/data&gt;&lt;/li&gt;\n  &lt;li&gt;&lt;data value=\"399\"&gt;Jumbo Ketchup&lt;/data&gt;&lt;/li&gt;\n  &lt;li&gt;&lt;data value=\"400\"&gt;Mega Jumbo Ketchup&lt;/data&gt;&lt;/li&gt;\n&lt;/ul&gt;\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example notranslate\"><code>data:hover::after {\n  content: \" (ID \" attr(value) \")\";\n  font-size: 0.7em;\n}\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "try_it_2",
+          "title": "Try it",
+          "isH3": false,
+          "content": "<interactive-example name=\"JavaScript Demo: Set.prototype[Symbol.iterator]()\"></interactive-example>\n<div class=\"code-example\"><pre class=\"brush: js interactive-example notranslate\"><code>const set = new Set();\n\nset.add(42);\nset.add(\"forty two\");\n\nconst iterator = set[Symbol.iterator]();\n\nconsole.log(iterator.next().value);\n// Expected output: 42\n\nconsole.log(iterator.next().value);\n// Expected output: \"forty two\"\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "try_it_3",
+          "title": "Try it",
+          "isH3": false,
+          "content": "<interactive-example name=\"CSS Demo: filter\"></interactive-example>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example-choice notranslate\"><code>filter: url(\"/shared-assets/images/examples/shadow.svg#element-id\");\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example-choice notranslate\"><code>filter: blur(5px);\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example-choice notranslate\"><code>filter: contrast(200%);\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example-choice notranslate\"><code>filter: grayscale(80%);\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example-choice notranslate\"><code>filter: hue-rotate(90deg);\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example-choice notranslate\"><code>filter: drop-shadow(16px 16px 20px red) invert(75%);\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: html interactive-example notranslate\"><code>&lt;section id=\"default-example\"&gt;\n  &lt;div class=\"example-container\"&gt;\n    &lt;img\n      id=\"example-element\"\n      src=\"/shared-assets/images/examples/firefox-logo.svg\"\n      width=\"200\" /&gt;\n  &lt;/div&gt;\n&lt;/section&gt;\n</code></pre></div>\n<div class=\"code-example\"><pre class=\"brush: css interactive-example notranslate\"><code>.example-container {\n  background-color: white;\n  width: 260px;\n  height: 260px;\n  display: flex;\n  align-items: center;\n  justify-content: center;\n}\n\n#example-element {\n  flex: 1;\n  padding: 30px;\n}\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "tables",
+          "title": "Tables",
+          "isH3": false,
+          "content": ""
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "markdown_table",
+          "title": "Markdown table",
+          "isH3": true,
+          "content": "<figure class=\"table-container\"><table>\n<thead>\n<tr>\n<th>Constant name</th>\n<th>Value</th>\n<th>Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td><code>QUERY_COUNTER_BITS_EXT</code></td>\n<td>0x8864</td>\n<td>The number of bits used to hold the query result for the given target.</td>\n</tr>\n<tr>\n<td><code>CURRENT_QUERY_EXT</code></td>\n<td>0x8865</td>\n<td>The currently active query.</td>\n</tr>\n<tr>\n<td><code>QUERY_RESULT_EXT</code></td>\n<td>0x8866</td>\n<td>The query result.</td>\n</tr>\n<tr>\n<td><code>QUERY_RESULT_AVAILABLE_EXT</code></td>\n<td>0x8867</td>\n<td>A Boolean indicating whether a query result is available.</td>\n</tr>\n<tr>\n<td><code>TIME_ELAPSED_EXT</code></td>\n<td>0x88BF</td>\n<td>Elapsed time (in nanoseconds).</td>\n</tr>\n<tr>\n<td><code>TIMESTAMP_EXT</code></td>\n<td>0x8E28</td>\n<td>The current time.</td>\n</tr>\n<tr>\n<td><code>GPU_DISJOINT_EXT</code></td>\n<td>0x8FBB</td>\n<td>A Boolean indicating whether the GPU performed any disjoint operation.</td>\n</tr>\n</tbody>\n</table></figure>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "html_table",
+          "title": "HTML table",
+          "isH3": true,
+          "content": "<figure class=\"table-container\"><table class=\"properties\">\n  <tbody>\n    <tr>\n      <th scope=\"row\">\n        <a href=\"/en-US/docs/Web/HTML/Guides/Content_categories\">Content categories</a>\n      </th>\n      <td>\n        <a href=\"/en-US/docs/Web/HTML/Guides/Content_categories#flow_content\">Flow content</a>,\n        <a href=\"/en-US/docs/Web/HTML/Guides/Content_categories#phrasing_content\">phrasing content</a>, palpable content.\n      </td>\n    </tr>\n    <tr>\n      <th scope=\"row\">Permitted content</th>\n      <td>\n        <a href=\"/en-US/docs/Web/HTML/Guides/Content_categories#phrasing_content\">Phrasing content</a>.\n      </td>\n    </tr>\n    <tr>\n      <th scope=\"row\">Tag omission</th>\n      <td>None, both the starting and ending tag are mandatory.</td>\n    </tr>\n    <tr>\n      <th scope=\"row\">Permitted parents</th>\n      <td>\n        Any element that accepts <a href=\"/en-US/docs/Web/HTML/Guides/Content_categories#phrasing_content\">phrasing content</a>.\n      </td>\n    </tr>\n    <tr>\n      <th scope=\"row\">Implicit ARIA role</th>\n      <td>\n        <a href=\"https://w3c.github.io/html-aria/#dfn-no-corresponding-role\" class=\"external\" target=\"_blank\">No corresponding role</a>\n      </td>\n    </tr>\n    <tr>\n      <th scope=\"row\">Permitted ARIA roles</th>\n      <td>Any</td>\n    </tr>\n    <tr>\n      <th scope=\"row\">DOM interface</th>\n      <td><a href=\"/en-US/docs/Web/API/HTMLElement\"><code>HTMLElement</code></a></td>\n    </tr>\n  </tbody>\n</table></figure>\n<figure class=\"table-container\"><table class=\"fullwidth-table\">\n  <caption>\n    Values for the content of <code>&lt;meta name=\"viewport\"&gt;</code>\n  </caption>\n  <thead>\n    <tr>\n      <th scope=\"col\">Value</th>\n      <th scope=\"col\">Possible subvalues</th>\n      <th scope=\"col\">Description</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td><code>width</code></td>\n      <td>A positive integer number, or the text <code>device-width</code></td>\n      <td>\n        Defines the pixel width of the viewport that you want the website to be\n        rendered at.\n      </td>\n    </tr>\n    <tr>\n      <td><code>user-scalable</code> <span class=\"badge inline readonly\" title=\"This value may not be changed.\">Read only</span></td>\n      <td><code>yes</code> or <code>no</code></td>\n      <td>\n        If set to <code>no</code>, the user is not able to zoom in the webpage.\n        The default is <code>yes</code>. Browser settings can ignore this rule,\n        and iOS10+ ignores it by default.\n      </td>\n    </tr>\n    <tr>\n      <td><code>viewport-fit</code></td>\n      <td><code>auto</code>, <code>contain</code> or <code>cover</code></td>\n      <td>\n        <p>\n          The <code>auto</code> value doesn't affect the initial layout viewport, and the whole web page is viewable.\n        </p>\n        <p>\n          The <code>contain</code> value means that the viewport is scaled to\n          fit the largest rectangle inscribed within the display.\n        </p>\n        <p>\n          The <code>cover</code> value means that the viewport is scaled to fill the device display.\n          It is highly recommended to make use of the <a href=\"/en-US/docs/Web/CSS/Reference/Values/env\">safe area inset</a> variables to\n          ensure that important content doesn't end up outside the display.\n        </p>\n      </td>\n    </tr>\n  </tbody>\n</table></figure>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "every_macro_under_the_sun",
+          "title": "Every macro under the sun",
+          "isH3": false,
+          "content": "<p><strong>Well, almost every macro. Hopefully only the ones that are in active use.</strong></p>\n<p>An <a href=\"/en-US/docs/Glossary/HTTP\">HTTP</a> error code meaning \"Bad Gateway\".</p>\n<p>A <a href=\"/en-US/docs/Glossary/Server\">server</a> can act as a gateway or proxy (go-between) between a client (like your Web browser) and another, upstream server.\nWhen you request to access a <a href=\"/en-US/docs/Glossary/URL\">URL</a>, the gateway server can relay your request to the upstream server.\n\"502\" means that the upstream server has returned an invalid response.</p>\n<ul>\n<li>JavaScript <a href=\"/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array\"><code>Array</code></a> on MDN</li>\n</ul>\n<p>Listening for mouse movement is even easier than listening for key presses: all we need is the listener for the <a href=\"/en-US/docs/Web/API/Element/mousemove_event\" title=\"mousemove\"><code>mousemove</code></a> event.</p>"
+        }
+      },
+      {
+        "type": "browser_compatibility",
+        "value": {
+          "id": "browser_compatibility",
+          "title": "Browser compatibility",
+          "isH3": false,
+          "query": "html.elements.video"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "axis-aligned_bounding_box",
+          "title": "Axis-Aligned Bounding Box",
+          "isH3": false,
+          "content": "<p>One of the simpler forms of collision detection is between two rectangles that are axis aligned — meaning no rotation.\nThe algorithm works by ensuring there is no gap between any of the 4 sides of the rectangles.\nAny gap means a collision does not exist.</p>\n<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">js</span></div><pre class=\"brush: js notranslate\"><code>var rect1 = { x: 5, y: 5, width: 50, height: 50 };\nvar rect2 = { x: 20, y: 10, width: 10, height: 10 };\n\nif (\n  rect1.x &lt; rect2.x + rect2.width &amp;&amp;\n  rect1.x + rect1.width &gt; rect2.x &amp;&amp;\n  rect1.y &lt; rect2.y + rect2.height &amp;&amp;\n  rect1.y + rect1.height &gt; rect2.y\n) {\n  // collision detected!\n}\n\n// filling in the values =&gt;\n\nif (5 &lt; 30 &amp;&amp; 55 &gt; 20 &amp;&amp; 5 &lt; 20 &amp;&amp; 55 &gt; 10) {\n  // collision detected!\n}\n</code></pre></div>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "rect_code",
+          "title": "Rect code",
+          "isH3": true,
+          "content": "<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">html</span></div><pre class=\"brush: html notranslate live-sample---rect_code\"><code>&lt;div id=\"cr-stage\"&gt;&lt;/div&gt;\n&lt;p&gt;\n  Move the rectangle with arrow keys. Green means collision, blue means no\n  collision.\n&lt;/p&gt;\n&lt;script src=\"https://cdnjs.cloudflare.com/ajax/libs/crafty/0.5.4/crafty-min.js\"&gt;&lt;/script&gt;\n</code></pre></div>\n<div class=\"code-example\"><div class=\"example-header\"><span class=\"language-name\">js</span></div><pre class=\"brush: js notranslate live-sample---rect_code\"><code>Crafty.init(200, 200);\n\nvar dim1 = { x: 5, y: 5, w: 50, h: 50 };\nvar dim2 = { x: 20, y: 10, w: 60, h: 40 };\n\nvar rect1 = Crafty.e(\"2D, Canvas, Color\").attr(dim1).color(\"red\");\n\nvar rect2 = Crafty.e(\"2D, Canvas, Color, Keyboard, Fourway\")\n  .fourway(2)\n  .attr(dim2)\n  .color(\"blue\");\n\nrect2.bind(\"EnterFrame\", function () {\n  if (\n    rect1.x &gt; rect2.x + rect2.w &amp;&amp;\n    rect1.x + rect1.w &gt; rect2.x &amp;&amp;\n    rect1.y &gt; rect2.y + rect2.h &amp;&amp;\n    rect1.h + rect1.y &gt; rect2.y\n  ) {\n    // collision detected!\n    this.color(\"green\");\n  } else {\n    // no collision\n    this.color(\"blue\");\n  }\n});\n</code></pre></div>\n<div class=\"code-example\"><div class=\"example-header\"></div><iframe class=\"sample-code-frame\" title=\"Rect code sample\" id=\"frame_rect_code\" width=\"700\" height=\"300\" src=\"about:blank\" data-live-path=\"/en-US/docs/MDN/Kitchensink/\" data-live-id=\"rect_code\" sandbox=\"allow-same-origin allow-scripts\" loading=\"lazy\"></iframe></div>\n<div class=\"notecard experimental\"><p><strong>Experimental:</strong> <strong>This is an <a href=\"/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental\">experimental technology</a></strong><br>Check the <a href=\"#browser_compatibility\">Browser compatibility table</a> carefully before using this in production.</p></div>\n<a href=\"/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo\"><code>tabs.mutedInfo</code></a>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "obsolete_cssom_interfaces_deprecated",
+          "title": "Obsolete CSSOM interfaces <abbr class=\"icon icon-deprecated\" title=\"Deprecated. Not for use in new websites.\">\n<span class=\"visually-hidden\">Deprecated</span>\n</abbr>",
+          "isH3": true,
+          "content": "<svg viewBox=\"-1 -1 650 42\" preserveAspectRatio=\"xMinYMin meet\"><a style=\"text-decoration: none;\" href=\"/en-US/docs/Web/API/Event\">\n        <rect x=\"0\" y=\"0\" width=\"75\" height=\"25\" fill=\"#fff\" stroke=\"#D4DDE4\" stroke-width=\"2px\"></rect>\n        <text x=\"37.5\" y=\"16\" font-size=\"10px\" fill=\"#4D4E53\" text-anchor=\"middle\">\n          Event\n        </text>\n      </a><line x1=\"75\" y1=\"14\" x2=\"105\" y2=\"14\" stroke=\"#D4DDE4\"></line><polyline points=\"75,14 85,9 85,19 75,14\" stroke=\"#D4DDE4\" fill=\"#fff\"></polyline><a style=\"text-decoration: none;\" href=\"/en-US/docs/Web/API/UIEvent\">\n        <rect x=\"105\" y=\"0\" width=\"75\" height=\"25\" fill=\"#fff\" stroke=\"#D4DDE4\" stroke-width=\"2px\"></rect>\n        <text x=\"142.5\" y=\"16\" font-size=\"10px\" fill=\"#4D4E53\" text-anchor=\"middle\">\n          UIEvent\n        </text>\n      </a><line x1=\"180\" y1=\"14\" x2=\"210\" y2=\"14\" stroke=\"#D4DDE4\"></line><polyline points=\"180,14 190,9 190,19 180,14\" stroke=\"#D4DDE4\" fill=\"#fff\"></polyline><a style=\"text-decoration: none;\" href=\"/en-US/docs/Web/API/MouseEvent\">\n        <rect x=\"210\" y=\"0\" width=\"80\" height=\"25\" fill=\"#fff\" stroke=\"#D4DDE4\" stroke-width=\"2px\"></rect>\n        <text x=\"250\" y=\"16\" font-size=\"10px\" fill=\"#4D4E53\" text-anchor=\"middle\">\n          MouseEvent\n        </text>\n      </a><line x1=\"290\" y1=\"14\" x2=\"320\" y2=\"14\" stroke=\"#D4DDE4\"></line><polyline points=\"290,14 300,9 300,19 290,14\" stroke=\"#D4DDE4\" fill=\"#fff\"></polyline><a style=\"text-decoration: none;\" href=\"/en-US/docs/Web/API/WheelEvent\">\n        <rect x=\"320\" y=\"0\" width=\"80\" height=\"25\" fill=\"#F4F7F8\" stroke=\"#D4DDE4\" stroke-width=\"2px\"></rect>\n        <text x=\"360\" y=\"16\" font-size=\"10px\" fill=\"#4D4E53\" text-anchor=\"middle\">\n          WheelEvent\n        </text>\n      </a></svg>\n<iframe width=\"100%\" height=\"820\" src=\"https://mdn.github.io/web-tech-games/index.html\" loading=\"lazy\"></iframe>\n<ul>\n<li><a href=\"/en-US/docs/Web/Accessibility\">Accessibility resources at MDN</a></li>\n<li><a href=\"https://en.wikipedia.org/wiki/Web_accessibility\" class=\"external\" target=\"_blank\">Web accessibility</a> on Wikipedia</li>\n</ul>\n<p>The <a href=\"https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs\" class=\"external\" target=\"_blank\"><code>AvailableInWorkers</code></a> macro inserts a localized note box indicating that a feature is available in a <a href=\"/en-US/docs/Web/API/Web_Workers_API\">Web worker</a> context.</p>\n<div class=\"notecard note\"><p><strong>Note:</strong> This feature is available in <a href=\"/en-US/docs/Web/API/Web_Workers_API\">Web Workers</a>.</p></div>\n<ul>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role\"><code>button</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/checkbox_role\"><code>checkbox</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitem_role\"><code>menuitem</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemcheckbox_role\"><code>menuitemcheckbox</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menuitemradio_role\"><code>menuitemradio</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/option_role\"><code>option</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/radio_role\"><code>radio</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role\"><code>switch</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role\"><code>tab</code></a></li>\n<li><a href=\"/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/treeitem_role\"><code>treeitem</code></a></li>\n</ul>\n<!--  -->\n<ul>\n<li>Create a <a href=\"/en-US/docs/Web/HTML/Reference/Elements/canvas\"><code>&lt;canvas&gt;</code></a> element and set its <code>width</code> and <code>height</code> attributes to the original, smaller resolution.</li>\n<li>Set its CSS <a href=\"/en-US/docs/Web/CSS/Reference/Properties/width\"><code>width</code></a> and <a href=\"/en-US/docs/Web/CSS/Reference/Properties/height\"><code>height</code></a> properties to be 2x or 4x the value of the HTML <code>width</code> and <code>height</code>.\nIf the canvas was created with a 128 pixel width, for example, we would set the CSS <code>width</code> to <code>512px</code> if we wanted a 4x scale.</li>\n<li>Set the <a href=\"/en-US/docs/Web/HTML/Reference/Elements/canvas\"><code>&lt;canvas&gt;</code></a> element's <code>image-rendering</code> CSS property to some value that does not make the image blurry.\nEither <code>crisp-edges</code> or <code>pixelated</code> will work. Check out the <a href=\"/en-US/docs/Web/CSS/Reference/Properties/image-rendering\"><code>image-rendering</code></a> article for more information on the differences between these values, and which prefixes to use depending on the browser.</li>\n</ul>\n<!--  -->\n<ul>\n<li>\n<p><a href=\"/en-US/docs/Glossary\">MDN Web Docs Glossary</a>:</p>\n<ul>\n<li><a href=\"/en-US/docs/Glossary/XMLHttpRequest\">XHR</a></li>\n</ul>\n</li>\n<li>\n<p><a href=\"https://en.wikipedia.org/wiki/AJAX\" class=\"external\" target=\"_blank\">AJAX</a> on Wikipedia</p>\n</li>\n<li>\n<p><a href=\"/en-US/docs/Learn_web_development/Core/Scripting/Network_requests\">Learn: Making network requests with JavaScript</a></p>\n</li>\n<li><a href=\"/en-US/docs/Web/API/XMLHttpRequest\"><code>XMLHttpRequest</code></a></li>\n<li><a href=\"/en-US/docs/Web/API/Fetch_API\"><code>Fetch API</code></a></li>\n<li>\n<p><a href=\"/en-US/docs/Web/API/Fetch_API/Using_Fetch\">Using Fetch API</a></p>\n</li>\n<li>\n<p><a href=\"https://peoplesofttutorial.com/difference-between-synchronous-and-asynchronous-messaging/\" class=\"external\" target=\"_blank\">Synchronous vs. Asynchronous Communications</a></p>\n</li>\n</ul>\n<!--  -->\n<ul>\n<li><a href=\"/en-US/docs/Web/SVG/Reference/Element/feGaussianBlur\"><code>&lt;feGaussianBlur&gt;</code></a></li>\n<li><a href=\"/en-US/docs/Web/SVG/Reference/Attribute/keySplines\"><code>keySplines</code></a> SVG attribute</li>\n<li><a href=\"/en-US/docs/Web/HTML/Reference/Global_attributes#dir\">dir</a></li>\n<li><a href=\"/en-US/docs/Web/HTML/Reference/Global_attributes#lang\">lang</a></li>\n<li><a href=\"/en-US/docs/Web/CSS/Reference/Selectors/:dir\"><code>:dir</code></a></li>\n<li><a href=\"/en-US/docs/Web/CSS/Reference/Properties/direction\"><code>direction</code></a></li>\n</ul>"
+        }
+      },
+      {
+        "type": "prose",
+        "value": {
+          "id": "types",
+          "title": "Types",
+          "isH3": false,
+          "content": "<dl>\n<dt id=\"alarms.alarm\"><a href=\"/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/Alarm\"><code>alarms.Alarm</code></a></dt>\n<dd>\n<p>Information about a particular alarm.</p>\n</dd>\n</dl>\n<div class=\"notecard nonstandard\"><p><strong>Non-standard:</strong> This feature is not standardized. We do not recommend using non-standard features in production, as they have limited browser support, and may change or be removed. However, they can be a suitable alternative in specific cases where no standard option exists.</p></div>\n<div class=\"notecard deprecated\"><p><strong>Deprecated:</strong> This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the <a href=\"#browser_compatibility\">compatibility table</a> at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.</p></div>\n<a href=\"iceberg.jpg\"><img src=\"/en-US/docs/MDN/Kitchensink/iceberg.jpg\" alt=\"Iceberg pic\" width=\"1400\" height=\"1050\" loading=\"lazy\"></a>"
+        }
+      }
+    ],
+    "isActive": true,
+    "isMarkdown": true,
+    "isTranslated": false,
+    "locale": "en-US",
+    "mdn_url": "/en-US/docs/MDN/Kitchensink",
+    "modified": "2025-11-06T14:49:20.000Z",
+    "native": "English (US)",
+    "noIndexing": true,
+    "other_translations": [
+      {
+        "locale": "en-US",
+        "title": "The MDN Content Kitchensink",
+        "native": "English (US)"
+      },
+      {
+        "locale": "de",
+        "title": "Der MDN Content Kitchensink",
+        "native": "Deutsch"
+      }
+    ],
+    "pageTitle": "The MDN Content Kitchensink - MDN Web Docs | MDN",
+    "parents": [
+      { "uri": "/en-US/docs/MDN", "title": "MDN Web Docs" },
+      {
+        "uri": "/en-US/docs/MDN/Kitchensink",
+        "title": "The MDN Content Kitchensink"
+      }
+    ],
+    "popularity": 0.00026709990444047106,
+    "short_title": "The MDN Content Kitchensink",
+    "source": {
+      "folder": "en-us/mdn/kitchensink",
+      "github_url": "https://github.com/mdn/content/blob/main/files/en-us/mdn/kitchensink/index.md",
+      "last_commit_url": "https://github.com/mdn/content/commit/f69b6693212029ce4b9fa0c753729044577af548",
+      "filename": "index.md"
+    },
+    "summary": "The kitchensink is a page that attempts to incorporate every possible content element and Yari macro.",
+    "title": "The MDN Content Kitchensink",
+    "toc": [
+      { "text": "About this page", "id": "about_this_page" },
+      { "text": "Prev/Next buttons", "id": "prevnext_buttons" },
+      { "text": "Code snippets", "id": "code_snippets" },
+      { "text": "Interactive examples", "id": "interactive_examples" },
+      { "text": "Try it", "id": "try_it" },
+      { "text": "Try it", "id": "try_it_2" },
+      { "text": "Try it", "id": "try_it_3" },
+      { "text": "Tables", "id": "tables" },
+      {
+        "text": "Every macro under the sun",
+        "id": "every_macro_under_the_sun"
+      },
+      { "text": "Browser compatibility", "id": "browser_compatibility" },
+      {
+        "text": "Axis-Aligned Bounding Box",
+        "id": "axis-aligned_bounding_box"
+      },
+      { "text": "Types", "id": "types" }
+    ],
+    "baseline": {
+      "baseline": "high",
+      "baseline_low_date": "2015-07-29",
+      "baseline_high_date": "2018-01-29",
+      "support": {
+        "chrome": "3",
+        "chrome_android": "18",
+        "edge": "12",
+        "firefox": "3.5",
+        "firefox_android": "4",
+        "safari": "3.1",
+        "safari_ios": "3"
+      },
+      "asterisk": true,
+      "feature": {
+        "status": {
+          "baseline": "high",
+          "baseline_low_date": "2015-07-29",
+          "baseline_high_date": "2018-01-29",
+          "support": {
+            "chrome": "3",
+            "chrome_android": "18",
+            "edge": "12",
+            "firefox": "3.5",
+            "firefox_android": "4",
+            "safari": "3.1",
+            "safari_ios": "3"
+          }
+        },
+        "description_html": "The <code>&#x3C;video></code> element plays videos or movies, optionally with controls provided by the browser.",
+        "name": "<video>"
+      }
+    },
+    "browserCompat": ["html.elements.video"],
+    "pageType": "guide"
+  },
+  "url": "/en-US/docs/MDN/Kitchensink",
+  "renderer": "Doc"
+}

--- a/test/helpers/client.js
+++ b/test/helpers/client.js
@@ -3,9 +3,9 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 
 import listen from "../../index.js";
 
-/** @param {number} port */
-export function createServer(port) {
-  return listen(port);
+export function createServer() {
+  // auto-assign port
+  return listen(0);
 }
 
 /** @param {number} port */

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -4,14 +4,14 @@ import { after, before, describe, it } from "node:test";
 import { createClient, createServer } from "./helpers/client.js";
 
 describe("server", () => {
-  /** @type {ReturnType<createServer>} */
+  /** @type {Awaited<ReturnType<createServer>>} */
   let server;
   /** @type {Awaited<ReturnType<createClient>>} */
   let client;
 
   before(async () => {
-    server = createServer(3003);
-    client = await createClient(3003);
+    server = await createServer();
+    client = await createClient(server.port);
   });
 
   it("should be named mdn", async () => {
@@ -25,6 +25,6 @@ describe("server", () => {
   });
 
   after(() => {
-    server.close();
+    server.listener.close();
   });
 });

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -43,7 +43,7 @@ describe("get-doc tool", () => {
     });
     /** @type {string} */
     const text = content[0].text;
-    assert.ok(text.includes("<h1>The MDN Content Kitchensink</h1>"));
+    assert.ok(text.startsWith("# The MDN Content Kitchensink"));
   });
 
   after(() => {

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -112,6 +112,28 @@ describe("get-doc tool", () => {
       const text = content[0].text;
       assert.deepEqual(text, `Error: ${path} doesn't look like an MDN url`);
     });
+
+    it("should handle path to missing doc", async () => {
+      const path = "/en-US/docs/MDN/Knisnehctik";
+
+      mockPool
+        .intercept({
+          path: path + "/index.json",
+          method: "GET",
+        })
+        .reply(404);
+
+      /** @type {any} */
+      const { content } = await client.callTool({
+        name: "get-doc",
+        arguments: {
+          path,
+        },
+      });
+      /** @type {string} */
+      const text = content[0].text;
+      assert.deepEqual(text, `404: Not Found for ${path}`);
+    });
   });
 
   after(() => {

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -99,6 +99,19 @@ describe("get-doc tool", () => {
       assert.ok(text.startsWith("# The MDN Content Kitchensink"));
     });
 
+    it("should accept path without leading slash", async () => {
+      /** @type {any} */
+      const { content } = await client.callTool({
+        name: "get-doc",
+        arguments: {
+          path: "en-US/docs/MDN/Kitchensink",
+        },
+      });
+      /** @type {string} */
+      const text = content[0].text;
+      assert.ok(text.startsWith("# The MDN Content Kitchensink"));
+    });
+
     it("should reject wrong base url", async () => {
       const path = "https://example.com/en-US/docs/MDN/Kitchensink";
       /** @type {any} */
@@ -133,6 +146,23 @@ describe("get-doc tool", () => {
       /** @type {string} */
       const text = content[0].text;
       assert.deepEqual(text, `404: Not Found for ${path}`);
+    });
+
+    it("should reject non-doc path", async () => {
+      const path = "/en-US/observatory";
+      /** @type {any} */
+      const { content } = await client.callTool({
+        name: "get-doc",
+        arguments: {
+          path,
+        },
+      });
+      /** @type {string} */
+      const text = content[0].text;
+      assert.deepEqual(
+        text,
+        `Error: ${path} doesn't look like the path to a piece of MDN documentation`,
+      );
     });
   });
 

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/reject-any-type */
 import assert from "node:assert/strict";
 import { after, before, describe, it } from "node:test";
 
@@ -14,14 +15,16 @@ describe("get-doc tool", () => {
     client = await createClient(server.port);
   });
 
-  it("should take a path argument", async () => {
+  it("should fetch requested document", async () => {
+    /** @type {any} */
     const { content } = await client.callTool({
       name: "get-doc",
       arguments: {
         path: "/en-US/docs/MDN/Kitchensink",
       },
     });
-    assert.deepEqual(content, []);
+    const { mdn_url } = JSON.parse(content[0].text);
+    assert.strictEqual(mdn_url, "/en-US/docs/MDN/Kitchensink");
   });
 
   after(() => {

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -41,8 +41,9 @@ describe("get-doc tool", () => {
         path: "/en-US/docs/MDN/Kitchensink",
       },
     });
-    const { mdn_url } = JSON.parse(content[0].text);
-    assert.strictEqual(mdn_url, "/en-US/docs/MDN/Kitchensink");
+    /** @type {string} */
+    const text = content[0].text;
+    assert.ok(text.includes("<h1>The MDN Content Kitchensink</h1>"));
   });
 
   after(() => {

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -4,6 +4,7 @@ import { after, before, beforeEach, describe, it } from "node:test";
 
 import { MockAgent, setGlobalDispatcher } from "undici";
 
+import docFixture from "../fixtures/kitchensink.json" with { type: "json" };
 import { createClient, createServer } from "../helpers/client.js";
 
 describe("get-doc tool", () => {
@@ -31,11 +32,7 @@ describe("get-doc tool", () => {
         path: "/en-US/docs/MDN/Kitchensink/index.json",
         method: "GET",
       })
-      .reply(200, {
-        doc: {
-          mdn_url: "mock",
-        },
-      });
+      .reply(200, docFixture);
 
     /** @type {any} */
     const { content } = await client.callTool({
@@ -45,7 +42,7 @@ describe("get-doc tool", () => {
       },
     });
     const { mdn_url } = JSON.parse(content[0].text);
-    assert.strictEqual(mdn_url, "mock");
+    assert.strictEqual(mdn_url, "/en-US/docs/MDN/Kitchensink");
   });
 
   after(() => {

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+
+import { createClient, createServer } from "../helpers/client.js";
+
+describe("get-doc tool", () => {
+  /** @type {Awaited<ReturnType<createServer>>} */
+  let server;
+  /** @type {Awaited<ReturnType<createClient>>} */
+  let client;
+
+  before(async () => {
+    server = await createServer();
+    client = await createClient(server.port);
+  });
+
+  it("should be callable", async () => {
+    const { content } = await client.callTool({
+      name: "get-doc",
+    });
+    assert.deepEqual(content, []);
+  });
+
+  after(() => {
+    server.listener.close();
+  });
+});

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -14,9 +14,12 @@ describe("get-doc tool", () => {
     client = await createClient(server.port);
   });
 
-  it("should be callable", async () => {
+  it("should take a path argument", async () => {
     const { content } = await client.callTool({
       name: "get-doc",
+      arguments: {
+        path: "/en-US/docs/MDN/Kitchensink",
+      },
     });
     assert.deepEqual(content, []);
   });

--- a/test/tools/global.test.js
+++ b/test/tools/global.test.js
@@ -36,6 +36,24 @@ describe("all tools", () => {
     );
   });
 
+  it("should have arguments with descriptions", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      const { properties } = tool.inputSchema;
+      if (properties === undefined) throw new Error("arguments are undefined");
+      const without = Object.entries(properties)
+        .filter(
+          // eslint-disable-next-line jsdoc/reject-any-type
+          ([_, schema]) => !("description" in /** @type {any} */ (schema)),
+        )
+        .map(([name]) => name);
+      assert.ok(
+        without.length === 0,
+        `${without.join(", ")} argument(s) don't have a description in tool ${tool.name}`,
+      );
+    }
+  });
+
   after(() => {
     server.listener.close();
   });

--- a/test/tools/global.test.js
+++ b/test/tools/global.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+
+import { createClient, createServer } from "../helpers/client.js";
+
+describe("all tools", () => {
+  /** @type {Awaited<ReturnType<createServer>>} */
+  let server;
+  /** @type {Awaited<ReturnType<createClient>>} */
+  let client;
+
+  before(async () => {
+    server = await createServer();
+    client = await createClient(server.port);
+  });
+
+  it("should have a title", async () => {
+    const { tools } = await client.listTools();
+    const without = tools
+      .filter((tool) => !("title" in tool))
+      .map(({ name }) => name);
+    assert.ok(
+      without.length === 0,
+      `${without.join(", ")} tool(s) don't have a title`,
+    );
+  });
+
+  after(() => {
+    server.listener.close();
+  });
+});

--- a/test/tools/global.test.js
+++ b/test/tools/global.test.js
@@ -25,6 +25,17 @@ describe("all tools", () => {
     );
   });
 
+  it("should have a description", async () => {
+    const { tools } = await client.listTools();
+    const without = tools
+      .filter((tool) => !("description" in tool))
+      .map(({ name }) => name);
+    assert.ok(
+      without.length === 0,
+      `${without.join(", ")} tool(s) don't have a description`,
+    );
+  });
+
   after(() => {
     server.listener.close();
   });

--- a/test/tools/global.test.js
+++ b/test/tools/global.test.js
@@ -25,6 +25,18 @@ describe("all tools", () => {
     );
   });
 
+  it("should be described in the MCP instructions", async () => {
+    const instructions = client.getInstructions();
+    const { tools } = await client.listTools();
+    const without = tools
+      .filter((tool) => !instructions?.includes(`\`${tool.name}\`: `))
+      .map(({ name }) => name);
+    assert.ok(
+      without.length === 0,
+      `${without.join(", ")} tool(s) aren't explained in the MCP instructions`,
+    );
+  });
+
   it("should have a description", async () => {
     const { tools } = await client.listTools();
     const without = tools

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -23,6 +23,7 @@ server.registerTool(
   "get-doc",
   {
     title: "Get documentation",
+    description: "Retrieve a page of MDN documentation as markdown.",
     inputSchema: {
       path: z.string(),
     },

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -25,7 +25,9 @@ server.registerTool(
     title: "Get documentation",
     description: "Retrieve a page of MDN documentation as markdown.",
     inputSchema: {
-      path: z.string(),
+      path: z
+        .string()
+        .describe("path or full URL: e.g. '/en-US/docs/Web/API/Headers'"),
     },
   },
   async ({ path }) => {

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -50,7 +50,12 @@ server.registerTool(
     }
 
     /** @type {import("@mdn/rari").DocPage} */
-    const context = await res.json();
+    const json = await res.json();
+    const context = {
+      ...json,
+      // @ts-expect-error
+      l10n: (x) => x,
+    }
     // TODO: expose better API for this from fred
     const renderedHtml = await collectResult(
       render(

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -1,3 +1,11 @@
+import { html, render } from "@lit-labs/ssr";
+import { collectResult } from "@lit-labs/ssr/lib/render-result.js";
+// @ts-expect-error: fred needs to expose types
+import { ContentSection } from "@mdn/fred/components/content-section/server.js";
+// @ts-expect-error
+import { asyncLocalStorage } from "@mdn/fred/components/server/async-local-storage.js";
+// @ts-expect-error
+import { runWithContext } from "@mdn/fred/symmetric-context/server.js";
 import z from "zod";
 
 import server from "../server.js";
@@ -12,12 +20,35 @@ server.registerTool(
   async ({ path }) => {
     const url = new URL(path, "https://developer.mozilla.org");
     const res = await fetch(url + "/index.json");
-    const json = await res.json();
+    /** @type {import("@mdn/rari").DocPage} */
+    const context = await res.json();
+    // TODO: expose better API for this from fred
+    const renderedHtml = await collectResult(
+      render(
+        await asyncLocalStorage.run(
+          {
+            componentsUsed: new Set(),
+            componentsWithStylesInHead: new Set(),
+          },
+          () =>
+            runWithContext(
+              {},
+              () => html`
+                <h1>${context.doc.title}</h1>
+                ${context.doc.body?.map((section) =>
+                  new ContentSection().render(context, section),
+                )}
+              `,
+            ),
+        ),
+      ),
+    );
+
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify(json.doc),
+          text: renderedHtml,
         },
       ],
     };

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -1,0 +1,7 @@
+import server from "../server.js";
+
+server.registerTool("get-doc", {}, async () => {
+  return {
+    content: [],
+  };
+});

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -55,7 +55,7 @@ server.registerTool(
       ...json,
       // @ts-expect-error
       l10n: (x) => x,
-    }
+    };
     // TODO: expose better API for this from fred
     const renderedHtml = await collectResult(
       render(

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -36,6 +36,10 @@ server.registerTool(
     }
 
     const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`${res.status}: ${res.statusText} for ${path}`);
+    }
+
     /** @type {import("@mdn/rari").DocPage} */
     const context = await res.json();
     // TODO: expose better API for this from fred

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -31,6 +31,11 @@ server.registerTool(
     if (url.host !== "developer.mozilla.org") {
       throw new Error(`Error: ${url} doesn't look like an MDN url`);
     }
+    if (!/^\/?([a-z-]+?\/)?docs\//i.test(url.pathname)) {
+      throw new Error(
+        `Error: ${path} doesn't look like the path to a piece of MDN documentation`,
+      );
+    }
     if (!url.pathname.endsWith("/index.json")) {
       url.pathname += "/index.json";
     }

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -1,7 +1,25 @@
+import z from "zod";
+
 import server from "../server.js";
 
-server.registerTool("get-doc", {}, async () => {
-  return {
-    content: [],
-  };
-});
+server.registerTool(
+  "get-doc",
+  {
+    inputSchema: {
+      path: z.string(),
+    },
+  },
+  async ({ path }) => {
+    const url = new URL(path, "https://developer.mozilla.org");
+    const res = await fetch(url + "/index.json");
+    const json = await res.json();
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(json.doc),
+        },
+      ],
+    };
+  },
+);

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -28,7 +28,14 @@ server.registerTool(
   },
   async ({ path }) => {
     const url = new URL(path, "https://developer.mozilla.org");
-    const res = await fetch(url + "/index.json");
+    if (url.host !== "developer.mozilla.org") {
+      throw new Error(`Error: ${url} doesn't look like an MDN url`);
+    }
+    if (!url.pathname.endsWith("/index.json")) {
+      url.pathname += "/index.json";
+    }
+
+    const res = await fetch(url);
     /** @type {import("@mdn/rari").DocPage} */
     const context = await res.json();
     // TODO: expose better API for this from fred

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -6,9 +6,18 @@ import { ContentSection } from "@mdn/fred/components/content-section/server.js";
 import { asyncLocalStorage } from "@mdn/fred/components/server/async-local-storage.js";
 // @ts-expect-error
 import { runWithContext } from "@mdn/fred/symmetric-context/server.js";
+import TurndownService from "turndown";
+// @ts-expect-error
+import turndownPluginGfm from "turndown-plugin-gfm";
 import z from "zod";
 
 import server from "../server.js";
+
+const turndownService = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+});
+turndownService.use(turndownPluginGfm.gfm);
 
 server.registerTool(
   "get-doc",
@@ -43,12 +52,12 @@ server.registerTool(
         ),
       ),
     );
-
+    const markdown = turndownService.turndown(renderedHtml);
     return {
       content: [
         {
           type: "text",
-          text: renderedHtml,
+          text: markdown,
         },
       ],
     };

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -22,6 +22,7 @@ turndownService.use(turndownPluginGfm.gfm);
 server.registerTool(
   "get-doc",
   {
+    title: "Get documentation",
     inputSchema: {
       path: z.string(),
     },


### PR DESCRIPTION
Quite a lot here, but as before: commits are atomic, so should be easiest to review by stepping through the commits. Generally I'll have added a test in one commit and made it pass in the commit after.

Adds a tool to fetch documentation from MDN and render it to markdown. It uses Fred to first render the context to HTML, which requires a little bit of strange patching of things Fred expects, and then converts that to markdown. The advantage of this is it means we don't have to re-implement the render logic for some sections (like Specifications) now or in the future. I'm going to look at exposing a nicer interface for markdown rendering from Fred.