### PR TITLE
chore(README): don't point to prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
 # mdn-mcp
 
-This is a work in progress prototype [MCP server](https://modelcontextprotocol.io/docs/learn/server-concepts) for MDN.
+This is an [MCP server](https://modelcontextprotocol.io/docs/learn/server-concepts) which provides access to MDN's search, documentation and Browser Compatibility Data.
 
-Development work is currently happening in the [`prototype` branch](https://github.com/mdn/mcp/tree/prototype).
+## Using the remote server
+
+Add the remote server to your tool of choice, e.g. in Claude Code:
+
+```
+claude mcp add --transport http mdn https://mdn-mcp-0445ad8e765a.herokuapp.com/mcp
+```
+
+## Using locally
+
+- Install dependencies: `npm install`
+- Start the server: `npm start`
+
+Add the server to your tool of choice, e.g. in Claude Code:
+
+```
+claude mcp add --transport http mdn-local http://localhost:3002/mcp
+```
+
+## Local development
+
+- Install dependencies: `npm install`
+- Start the development server, MCP inspector and tests: `npm run dev`
+- Your browser should automatically open the MCP inspector, and the server will restart when you make changes


### PR DESCRIPTION
`main` branch is fully functional, and deployed to heroku, so updating the README to no longer point at the prototype