### PR TITLE
ci(auto-merge): add workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,6 @@
 
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
+/package.json       @mdn/engineering @mdn-bot
+/package-lock.json  @mdn/engineering @mdn-bot
 /SECURITY.md @mdn/engineering

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,5 +10,7 @@ jobs:
   auto-merge:
     if: github.repository_owner == 'mdn'
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    with:
+      auto-merge: true
     secrets:
       GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    if: github.repository_owner == 'mdn'
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
### Description

Adds the `auto-merge.yml` workflow, and adds @mdn-bot as code owner of `package.json` + `package-lock.json`

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1395.
