### PR TITLE
feat: add tool annotations

### DIFF
--- a/test/tools/global.test.js
+++ b/test/tools/global.test.js
@@ -48,6 +48,33 @@ describe("all tools", () => {
     );
   });
 
+  it("should have annotations", async () => {
+    // https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy
+    // E. MCP servers must provide all applicable annotations for their tools,
+    // in particular readOnlyHint, destructiveHint, and title.
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      const { annotations } = tool;
+      assert.equal(
+        annotations?.title,
+        tool.title,
+        `${tool.name} annotations.title doesn't match title`,
+      );
+      for (const hint of /** @type {const} */ ([
+        "readOnlyHint",
+        "destructiveHint",
+        "idempotentHint",
+        "openWorldHint",
+      ])) {
+        assert.equal(
+          typeof annotations?.[hint],
+          "boolean",
+          `${tool.name} annotations.${hint} is not defined`,
+        );
+      }
+    }
+  });
+
   it("should have arguments with descriptions", async () => {
     const { tools } = await client.listTools();
     for (const tool of tools) {

--- a/tools/get-compat.js
+++ b/tools/get-compat.js
@@ -4,11 +4,19 @@ import { NonSentryError } from "../sentry/error.js";
 
 /** @param {InstanceType<import("../server.js").ExtendedServer>} server */
 export function registerGetCompatTool(server) {
+  const title = "Get browser compatibility data";
   server.registerTool(
     "get-compat",
     {
-      title: "Get browser compatibility data",
+      title,
       description: "Retrieve MDN's Browser Compatibility Data.",
+      annotations: {
+        title,
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       inputSchema: {
         key: z
           .string()

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -15,11 +15,19 @@ turndownService.use(turndownPluginGfm.gfm);
 
 /** @param {InstanceType<import("../server.js").ExtendedServer>} server */
 export function registerGetDocTool(server) {
+  const title = "Get documentation";
   server.registerTool(
     "get-doc",
     {
-      title: "Get documentation",
+      title,
       description: "Retrieve a page of MDN documentation as markdown.",
+      annotations: {
+        title,
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       inputSchema: {
         path: z
           .string()

--- a/tools/search.js
+++ b/tools/search.js
@@ -7,11 +7,19 @@ import z from "zod";
 
 /** @param {InstanceType<import("../server.js").ExtendedServer>} server */
 export function registerSearchTool(server) {
+  const title = "Search";
   server.registerTool(
     "search",
     {
-      title: "Search",
+      title,
       description: "Search MDN for documentation about web technologies.",
+      annotations: {
+        title,
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
       inputSchema: {
         query: z.string().describe("search terms: e.g. 'array methods'"),
       },


### PR DESCRIPTION
Add [tool annotations](https://modelcontextprotocol.io/specification/draft/schema#toolannotations) as required by https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy#h_9fdb5d0031:

> E. MCP servers must provide all applicable [annotations](https://modelcontextprotocol.io/specification/draft/schema#toolannotations) for their tools, in particular readOnlyHint, destructiveHint, and title.