### PR TITLE
docs(README): Update privacy notice and add acceptable usage policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Our hope is that it gives LLM ChatBots and Coding Agents more accurate informati
 
 ## Privacy and Data Retention
 
-This MCP is being run as an experiment. While it is an experiment, we will be storing data about the queries we receive. This data will **not** be associated with any information designed to identify users. However, while unlikely, it is possible that private information that you divulge to the LLM could be included in these queries. Please don't use this MCP if this is a concern to you.
-
-As this MCP is experimental it may be withdrawn at any time, in particular, the URL will change before it becomes production ready.
+This MCP is being run as an experiment. While it is an experiment, we will be storing data about the queries we receive. Please see our [privacy notice](https://www.mozilla.org/en-US/privacy/websites/) for more information on interaction data we may collect. This data will **not** be associated with any information designed to identify users. However, while unlikely, it is possible that private information that you divulge to the LLM could be included in these queries. Please don't use this MCP if this is a concern to you.
 
 To opt out of first-party analytics, send the `X-Moz-1st-Party-Data-Opt-Out: 1` header along with requests to the MCP.
+
+By using our MCP, you agree to comply with our [Acceptable Usage Policy](https://www.mozilla.org/en-US/about/legal/acceptable-use/).
+
+As this MCP is experimental it may be withdrawn at any time.
 
 ## Using the remote server
 


### PR DESCRIPTION
Updated privacy section with a link to Mozilla's privacy notice, added an acceptable usage policy link, and removed the note about the URL changing before production.