### PR TITLE
fix(get-docs): handle redirects, report in response

### DIFF
--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -245,6 +245,40 @@ describe("get-doc tool", () => {
     assert.ok(text.startsWith("# Headers"));
   });
 
+  it("should handle a redirect loop", async () => {
+    mockPool
+      .intercept({
+        path: "/en-US/docs/redirect-loop/index.json",
+        method: "GET",
+      })
+      .reply(302, "", {
+        headers: { location: "/en-US/docs/redirect-loop" },
+      })
+      .persist();
+    mockPool
+      .intercept({
+        path: "/en-US/docs/redirect-loop",
+        method: "GET",
+      })
+      .reply(200, "<!doctype html>")
+      .persist();
+
+    /** @type {any} */
+    const { content, isError } = await client.callTool({
+      name: "get-doc",
+      arguments: {
+        path: "/en-US/docs/redirect-loop",
+      },
+    });
+    assert.equal(isError, true);
+    /** @type {string} */
+    const text = content[0].text;
+    assert.ok(
+      text.startsWith("Error: `/en-US/docs/redirect-loop`"),
+      "response starts with 'Error: `<originalPath>`'",
+    );
+  });
+
   describe("bcd keys", () => {
     it("should have none", async () => {
       mockPool

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -208,6 +208,40 @@ describe("get-doc tool", () => {
     assert.ok(text.startsWith("# Headers"));
   });
 
+  it("should handle a redirect to a new index.json", async () => {
+    mockPool
+      .intercept({
+        path: "/en-US/docs/redirects-to-json/index.json",
+        method: "GET",
+      })
+      .reply(302, "", {
+        headers: {
+          location: "/en-US/docs/Web/API/Headers/index.json",
+        },
+      });
+    mockPool
+      .intercept({
+        path: "/en-US/docs/Web/API/Headers/index.json",
+        method: "GET",
+      })
+      .reply(200, headersDoc);
+
+    /** @type {any} */
+    const { content, isError } = await client.callTool({
+      name: "get-doc",
+      arguments: {
+        path: "/en-US/docs/redirects-to-json",
+      },
+    });
+    assert.equal(isError, undefined);
+    const [_, text] = frontmatterSplit(content[0].text);
+    assert.ok(
+      text.startsWith(
+        "`/en-US/docs/redirects-to-json` redirected to `/en-US/docs/Web/API/Headers`:\n# Headers",
+      ),
+    );
+  });
+
   it("should handle a redirect to a section in HTML", async () => {
     mockPool
       .intercept({
@@ -242,7 +276,11 @@ describe("get-doc tool", () => {
     });
     assert.equal(isError, undefined);
     const [_, text] = frontmatterSplit(content[0].text);
-    assert.ok(text.startsWith("# Headers"));
+    assert.ok(
+      text.startsWith(
+        "`/en-US/docs/redirects-to-section` redirected to `/en-US/docs/Web/API/Headers#modification_restrictions`, the contents of the full page follows:\n# Headers",
+      ),
+    );
   });
 
   it("should handle a redirect to an external url", async () => {

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -256,12 +256,6 @@ describe("get-doc tool", () => {
       });
     mockPool
       .intercept({
-        path: "/en-US/docs/Web/API/Headers",
-        method: "GET",
-      })
-      .reply(200, "<!doctype html>");
-    mockPool
-      .intercept({
         path: "/en-US/docs/Web/API/Headers/index.json",
         method: "GET",
       })

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -208,7 +208,7 @@ describe("get-doc tool", () => {
     assert.ok(text.startsWith("# Headers"));
   });
 
-  it("should handle a redirect to a new index.json", async () => {
+  it("handles redirect to other index.json", async () => {
     mockPool
       .intercept({
         path: "/en-US/docs/redirects-to-json/index.json",
@@ -242,7 +242,7 @@ describe("get-doc tool", () => {
     );
   });
 
-  it("should handle a redirect to a section in HTML", async () => {
+  it("handles broken redirect to a fragment followed by /index.json", async () => {
     mockPool
       .intercept({
         path: "/en-US/docs/redirects-to-section/index.json",

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -318,13 +318,6 @@ describe("get-doc tool", () => {
         headers: { location: "/en-US/docs/redirect-loop" },
       })
       .persist();
-    mockPool
-      .intercept({
-        path: "/en-US/docs/redirect-loop",
-        method: "GET",
-      })
-      .reply(200, "<!doctype html>")
-      .persist();
 
     /** @type {any} */
     const { content, isError } = await client.callTool({

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -208,6 +208,43 @@ describe("get-doc tool", () => {
     assert.ok(text.startsWith("# Headers"));
   });
 
+  it("should handle a redirect to a section in HTML", async () => {
+    mockPool
+      .intercept({
+        path: "/en-US/docs/redirects-to-section/index.json",
+        method: "GET",
+      })
+      .reply(302, "", {
+        headers: {
+          location:
+            "/en-US/docs/Web/API/Headers#modification_restrictions/index.json",
+        },
+      });
+    mockPool
+      .intercept({
+        path: "/en-US/docs/Web/API/Headers",
+        method: "GET",
+      })
+      .reply(200, "<!doctype html>");
+    mockPool
+      .intercept({
+        path: "/en-US/docs/Web/API/Headers/index.json",
+        method: "GET",
+      })
+      .reply(200, headersDoc);
+
+    /** @type {any} */
+    const { content, isError } = await client.callTool({
+      name: "get-doc",
+      arguments: {
+        path: "/en-US/docs/redirects-to-section",
+      },
+    });
+    assert.equal(isError, undefined);
+    const [_, text] = frontmatterSplit(content[0].text);
+    assert.ok(text.startsWith("# Headers"));
+  });
+
   describe("bcd keys", () => {
     it("should have none", async () => {
       mockPool

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -245,6 +245,37 @@ describe("get-doc tool", () => {
     assert.ok(text.startsWith("# Headers"));
   });
 
+  it("should handle a redirect to an external url", async () => {
+    mockPool
+      .intercept({
+        path: "/en-US/docs/redirects-to-external/index.json",
+        method: "GET",
+      })
+      .reply(302, "", {
+        headers: {
+          location: "https://example.com/path/index.json",
+        },
+      });
+
+    /** @type {any} */
+    const { content, isError } = await client.callTool({
+      name: "get-doc",
+      arguments: {
+        path: "/en-US/docs/redirects-to-external",
+      },
+    });
+    assert.equal(isError, undefined);
+    const [_, text] = frontmatterSplit(content[0].text);
+    assert.ok(
+      text.includes("`/en-US/docs/redirects-to-external`"),
+      "response includes request path",
+    );
+    assert.ok(
+      text.includes("`https://example.com/path`"),
+      "response includes redirect path",
+    );
+  });
+
   it("should handle a redirect loop", async () => {
     mockPool
       .intercept({

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -237,7 +237,7 @@ describe("get-doc tool", () => {
     const [_, text] = frontmatterSplit(content[0].text);
     assert.ok(
       text.startsWith(
-        "`/en-US/docs/redirects-to-json` redirected to `/en-US/docs/Web/API/Headers`:\n# Headers",
+        "(`/en-US/docs/redirects-to-json` redirected to `/en-US/docs/Web/API/Headers`.)\n# Headers",
       ),
     );
   });
@@ -272,7 +272,7 @@ describe("get-doc tool", () => {
     const [_, text] = frontmatterSplit(content[0].text);
     assert.ok(
       text.startsWith(
-        "`/en-US/docs/redirects-to-section` redirected to `/en-US/docs/Web/API/Headers#modification_restrictions`, the contents of the full page follows:\n# Headers",
+        "(`/en-US/docs/redirects-to-section` redirected to `/en-US/docs/Web/API/Headers#modification_restrictions`, the contents of the full page follows.)\n# Headers",
       ),
     );
   });

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -58,8 +58,29 @@ export function registerGetDocTool(server) {
           url.pathname += "/index.json";
         }
 
-        const res = await fetch(url);
+        const res = await fetch(url, { redirect: "manual" });
         if (!res.ok) {
+          if (res.status >= 300 && res.status <= 399) {
+            const location = res.headers.get("location");
+            if (typeof location === "string") {
+              const next = new URL(location, url);
+              if (next.host === "developer.mozilla.org") {
+                path = next.pathname;
+                continue;
+              } else {
+                next.pathname = next.pathname.replace(/\/index\.json$/, "");
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `The MDN path \`${originalPath}\` redirects to \`${next}\`, consider fetching the contents of that page.`,
+                    },
+                  ],
+                };
+              }
+            }
+            throw new Error(`Error: Malformed redirect from ${path}`);
+          }
           if (res.status === 404) {
             throw new NonSentryError(`Error: We couldn't find ${path}`, "404");
           }
@@ -67,19 +88,7 @@ export function registerGetDocTool(server) {
         }
 
         /** @type {import("@mdn/rari").DocPage} */
-        let context;
-        try {
-          context = await res.json();
-        } catch (error) {
-          if (error instanceof SyntaxError && res.redirected) {
-            // we've been redirected to something which isn't json
-            const resUrl = new URL(res.url);
-            // try again with this new URL
-            path = resUrl.pathname;
-            continue;
-          }
-          throw error;
-        }
+        const context = await res.json();
         const renderedHtml = await renderSimplified(context.url, context);
         const markdown = turndownService.turndown(renderedHtml);
 

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -40,6 +40,7 @@ export function registerGetDocTool(server) {
     },
     async ({ path }, request) => {
       const originalPath = path;
+      let redirected = false;
       for (let i = 0; i < 5; i++) {
         const url = new URL(path, BASE_URL);
         if (url.host !== "developer.mozilla.org") {
@@ -64,11 +65,13 @@ export function registerGetDocTool(server) {
             const location = res.headers.get("location");
             if (typeof location === "string") {
               const next = new URL(location, url);
+              next.pathname = next.pathname.replace(/\/index\.json$/, "");
+              next.hash = next.hash.replace(/\/index\.json$/, "");
               if (next.host === "developer.mozilla.org") {
-                path = next.pathname;
+                path = next.pathname + next.hash;
+                redirected = true;
                 continue;
               } else {
-                next.pathname = next.pathname.replace(/\/index\.json$/, "");
                 return {
                   content: [
                     {
@@ -78,6 +81,7 @@ export function registerGetDocTool(server) {
                   ],
                 };
               }
+              /* node:coverage ignore next 3 */
             }
             throw new Error(`Error: Malformed redirect from ${path}`);
           }
@@ -104,6 +108,12 @@ export function registerGetDocTool(server) {
           }
           frontmatter += "---\n";
         }
+        let note = "";
+        if (redirected && !path.endsWith(originalPath)) {
+          note = url.hash
+            ? `\`${originalPath}\` redirected to \`${path}\`, the contents of the full page follows:\n`
+            : `\`${originalPath}\` redirected to \`${path}\`:\n`;
+        }
 
         submitEvent(fetched, request, { path: context.url });
 
@@ -111,7 +121,7 @@ export function registerGetDocTool(server) {
           content: [
             {
               type: "text",
-              text: frontmatter + markdown,
+              text: frontmatter + note + markdown,
             },
           ],
         };

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -9,13 +9,15 @@ import { fetched } from "../glean/generated/getDoc.js";
 import { submitEvent } from "../glean/glean.js";
 import { NonSentryError } from "../sentry/error.js";
 
+const BASE_URL = "https://developer.mozilla.org";
+const MDN_HOST = "developer.mozilla.org";
+const MAX_REDIRECTS = 5;
+
 const turndownService = new TurndownService({
   headingStyle: "atx",
   codeBlockStyle: "fenced",
 });
 turndownService.use(turndownPluginGfm.gfm);
-
-const BASE_URL = "https://developer.mozilla.org";
 
 /** @param {InstanceType<import("../server.js").ExtendedServer>} server */
 export function registerGetDocTool(server) {
@@ -41,9 +43,9 @@ export function registerGetDocTool(server) {
     async ({ path }, request) => {
       const originalPath = path;
       let redirected = false;
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < MAX_REDIRECTS; i++) {
         const url = new URL(path, BASE_URL);
-        if (url.host !== "developer.mozilla.org") {
+        if (url.host !== MDN_HOST) {
           throw new NonSentryError(
             `Error: ${url} doesn't look like an MDN url`,
             "non_mdn_host",
@@ -65,9 +67,11 @@ export function registerGetDocTool(server) {
             const location = res.headers.get("location");
             if (typeof location === "string") {
               const next = new URL(location, url);
+              // strip "/index.json" from path to get the page path:
               next.pathname = next.pathname.replace(/\/index\.json$/, "");
+              // dex can append "/index.json" to the hash, so remove that:
               next.hash = next.hash.replace(/\/index\.json$/, "");
-              if (next.host === "developer.mozilla.org") {
+              if (next.host === MDN_HOST) {
                 path = next.pathname + next.hash;
                 redirected = true;
                 continue;
@@ -81,10 +85,13 @@ export function registerGetDocTool(server) {
                   ],
                 };
               }
-              /* node:coverage ignore next 3 */
+              /* node:coverage disable */
             }
-            throw new Error(`Error: Malformed redirect from ${path}`);
+            throw new Error(
+              `Error: Malformed ${res.status} redirect from ${path}, missing location header.`,
+            );
           }
+          /* node:coverage enable */
           if (res.status === 404) {
             throw new NonSentryError(`Error: We couldn't find ${path}`, "404");
           }
@@ -110,9 +117,7 @@ export function registerGetDocTool(server) {
         }
         let note = "";
         if (redirected && !path.endsWith(originalPath)) {
-          note = url.hash
-            ? `\`${originalPath}\` redirected to \`${path}\`, the contents of the full page follows:\n`
-            : `\`${originalPath}\` redirected to \`${path}\`:\n`;
+          note = `(\`${originalPath}\` redirected to \`${path}\`${url.hash ? ", the contents of the full page follows" : ""}.)\n`;
         }
 
         submitEvent(fetched, request, { path: context.url });
@@ -126,7 +131,9 @@ export function registerGetDocTool(server) {
           ],
         };
       }
-      throw new Error(`Error: \`${originalPath}\` redirected too many times`);
+      throw new Error(
+        `Error: \`${originalPath}\` redirected more than ${MAX_REDIRECTS} times`,
+      );
     },
   );
 }

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -15,6 +15,8 @@ const turndownService = new TurndownService({
 });
 turndownService.use(turndownPluginGfm.gfm);
 
+const BASE_URL = "https://developer.mozilla.org";
+
 /** @param {InstanceType<import("../server.js").ExtendedServer>} server */
 export function registerGetDocTool(server) {
   const title = "Get documentation";
@@ -37,59 +39,75 @@ export function registerGetDocTool(server) {
       },
     },
     async ({ path }, request) => {
-      const url = new URL(path, "https://developer.mozilla.org");
-      if (url.host !== "developer.mozilla.org") {
-        throw new NonSentryError(
-          `Error: ${url} doesn't look like an MDN url`,
-          "non_mdn_host",
-        );
-      }
-      if (!/^\/?([a-z-]+?\/)?docs\//i.test(url.pathname)) {
-        throw new NonSentryError(
-          `Error: ${path} doesn't look like the path to a piece of MDN documentation`,
-          "non_doc_path",
-        );
-      }
-      if (!url.pathname.endsWith("/index.json")) {
-        url.pathname += "/index.json";
-      }
-
-      const res = await fetch(url);
-      if (!res.ok) {
-        if (res.status === 404) {
-          throw new NonSentryError(`Error: We couldn't find ${path}`, "404");
+      const originalPath = path;
+      for (let i = 0; i < 5; i++) {
+        const url = new URL(path, BASE_URL);
+        if (url.host !== "developer.mozilla.org") {
+          throw new NonSentryError(
+            `Error: ${url} doesn't look like an MDN url`,
+            "non_mdn_host",
+          );
         }
-        throw new Error(`${res.status}: ${res.statusText} for ${path}`);
-      }
-
-      /** @type {import("@mdn/rari").DocPage} */
-      const context = await res.json();
-      const renderedHtml = await renderSimplified(context.url, context);
-      const markdown = turndownService.turndown(renderedHtml);
-
-      let frontmatter = "";
-      const { browserCompat } = context.doc;
-      if (browserCompat) {
-        frontmatter += "---\n";
-        if (browserCompat.length > 1) {
-          frontmatter += "compat-keys:\n";
-          frontmatter += browserCompat.map((key) => `  - ${key}\n`).join("");
-        } else {
-          frontmatter += `compat-key: ${browserCompat[0]}\n`;
+        if (!/^\/?([a-z-]+?\/)?docs\//i.test(url.pathname)) {
+          throw new NonSentryError(
+            `Error: ${path} doesn't look like the path to a piece of MDN documentation`,
+            "non_doc_path",
+          );
         }
-        frontmatter += "---\n";
+        if (!url.pathname.endsWith("/index.json")) {
+          url.pathname += "/index.json";
+        }
+
+        const res = await fetch(url);
+        if (!res.ok) {
+          if (res.status === 404) {
+            throw new NonSentryError(`Error: We couldn't find ${path}`, "404");
+          }
+          throw new Error(`${res.status}: ${res.statusText} for ${path}`);
+        }
+
+        /** @type {import("@mdn/rari").DocPage} */
+        let context;
+        try {
+          context = await res.json();
+        } catch (error) {
+          if (error instanceof SyntaxError && res.redirected) {
+            // we've been redirected to something which isn't json
+            const resUrl = new URL(res.url);
+            // try again with this new URL
+            path = resUrl.pathname;
+            continue;
+          }
+          throw error;
+        }
+        const renderedHtml = await renderSimplified(context.url, context);
+        const markdown = turndownService.turndown(renderedHtml);
+
+        let frontmatter = "";
+        const { browserCompat } = context.doc;
+        if (browserCompat) {
+          frontmatter += "---\n";
+          if (browserCompat.length > 1) {
+            frontmatter += "compat-keys:\n";
+            frontmatter += browserCompat.map((key) => `  - ${key}\n`).join("");
+          } else {
+            frontmatter += `compat-key: ${browserCompat[0]}\n`;
+          }
+          frontmatter += "---\n";
+        }
+
+        submitEvent(fetched, request, { path: context.url });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: frontmatter + markdown,
+            },
+          ],
+        };
       }
-
-      submitEvent(fetched, request, { path: context.url });
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: frontmatter + markdown,
-          },
-        ],
-      };
+      throw new Error(`Error: \`${originalPath}\` redirected too many times`);
     },
   );
 }


### PR DESCRIPTION
Fixes https://github.com/mdn/mcp/issues/209

Would recommend reviewing with whitespace changes disabled, as one commit indents the majority of the get-doc function body.

Handles both the case in the above issue (dex redirects to a html anchor), as well as redirects to external URLs. Also adds context whenever a redirect happens, to give the LLM context as to why page B was returned when page A was requested.