### PR TITLE
build(deps-dev): bump npm from 11.6.2 to 11.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,16 @@
     "test:watch": "node --test --watch 'test/**/*.test.js'",
     "glean:generate": "glean translate glean/metrics.yaml -f javascript -o glean/generated/ && glean translate glean/metrics.yaml -f typescript -o glean/generated/ && sed -i 's/ DO NOT COMMIT\\.//g' glean/generated/*"
   },
+  "packageManager": "npm@11.16.0",
+  "engines": {
+    "node": ">=24"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.8.0"
+    }
+  },
   "dependencies": {
     "@lit-labs/ssr": "^4.1.0",
     "@mdn/fred": "^2.6.5",
@@ -46,9 +56,5 @@
     "typescript-eslint": "^8.62.1",
     "undici": "^8.0.2",
     "zod": "^4.4.3"
-  },
-  "packageManager": "npm@11.6.2",
-  "engines": {
-    "node": ">=24"
   }
 }


### PR DESCRIPTION
### Description

Bumps npm from 11.6.2 to 11.16.0:

- Updates `package.json`:
  - Sets `packageManager` field to `npm@11.16.0`.
  - Adds `devEngines.packageManager` field with `{ "name": "npm", "version": ">=11.8.0" }`.
- ~~Updates `.nvmrc`~~ (left at v24)
- ~~Updates `package-lock.json`~~ (no changes)

### Motivation

Attempt to avoid issues where Dependabot occasionally omits indirect dependencies.

### Additional details

### Related issues and pull requests

Same as https://github.com/mdn/content/pull/42778 and https://github.com/mdn/translated-content/pull/34587.