### PR TITLE
fix(sentry): exclude 406 from logging

### DIFF
--- a/test/tools/get-compat.test.js
+++ b/test/tools/get-compat.test.js
@@ -111,6 +111,31 @@ describe("get-compat tool", () => {
     assert.match(text, /^MCP error/, "response starts with 'MCP error'");
   });
 
+  it("should handle blocked request", async () => {
+    const key = "malicious_payload";
+
+    mockPool
+      .intercept({
+        path: `/bcd/api/v0/current/${key}.json`,
+        method: "GET",
+      })
+      .reply(406);
+
+    /** @type {any} */
+    const { content } = await client.callTool({
+      name: "get-compat",
+      arguments: {
+        key,
+      },
+    });
+    /** @type {string} */
+    const text = content[0].text;
+    assert.deepEqual(
+      text,
+      `Error: We couldn't fetch "${key}" from the Browser Compatibility Data.`,
+    );
+  });
+
   it("should handle bcd api server error", async () => {
     const key = "javascript.builtins.Array.Array";
 
@@ -179,6 +204,30 @@ describe("get-compat tool", () => {
       assert.deepEqual(record.mock.calls[0]?.arguments[0], {
         tool: "get-compat",
         reason: "404",
+        user_agent: "node",
+      });
+    });
+
+    it("should send error for blocked request", async () => {
+      const key = "malicious_payload";
+      const record = mock.method(silentError, "record");
+
+      mockPool
+        .intercept({
+          path: `/bcd/api/v0/current/${key}.json`,
+          method: "GET",
+        })
+        .reply(406);
+
+      await client.callTool({
+        name: "get-compat",
+        arguments: { key },
+      });
+
+      assert.equal(record.mock.calls.length, 1);
+      assert.deepEqual(record.mock.calls[0]?.arguments[0], {
+        tool: "get-compat",
+        reason: "406",
         user_agent: "node",
       });
     });

--- a/test/tools/get-doc.test.js
+++ b/test/tools/get-doc.test.js
@@ -148,6 +148,28 @@ describe("get-doc tool", () => {
       assert.deepEqual(text, `Error: We couldn't find ${path}`);
     });
 
+    it("should handle blocked request", async () => {
+      const path = "/en-US/docs/malicious_payload";
+
+      mockPool
+        .intercept({
+          path: path + "/index.json",
+          method: "GET",
+        })
+        .reply(406);
+
+      /** @type {any} */
+      const { content } = await client.callTool({
+        name: "get-doc",
+        arguments: {
+          path,
+        },
+      });
+      /** @type {string} */
+      const text = content[0].text;
+      assert.deepEqual(text, `Error: We couldn't fetch ${path}`);
+    });
+
     it("should handle upstream server error", async () => {
       const path = "/en-US/docs/MDN/Knisnehctik";
 
@@ -491,6 +513,32 @@ describe("get-doc tool", () => {
       assert.deepEqual(record.mock.calls[0]?.arguments[0], {
         tool: "get-doc",
         reason: "404",
+        user_agent: "node",
+      });
+    });
+
+    it("should send error for blocked request", async () => {
+      const record = mock.method(silentError, "record");
+      const path = "/en-US/docs/malicious_payload";
+
+      mockPool
+        .intercept({
+          path: path + "/index.json",
+          method: "GET",
+        })
+        .reply(406);
+
+      await client.callTool({
+        name: "get-doc",
+        arguments: {
+          path,
+        },
+      });
+
+      assert.equal(record.mock.calls.length, 1);
+      assert.deepEqual(record.mock.calls[0]?.arguments[0], {
+        tool: "get-doc",
+        reason: "406",
         user_agent: "node",
       });
     });

--- a/test/tools/search.test.js
+++ b/test/tools/search.test.js
@@ -4,6 +4,7 @@ import { after, before, describe, it, mock } from "node:test";
 
 import { MockAgent, setGlobalDispatcher } from "undici";
 
+import { silentError } from "../../glean/generated/error.js";
 import { completed } from "../../glean/generated/search.js";
 import clipboardApiMetadata from "../fixtures/clipboard-api-metadata.json" with { type: "json" };
 import clipboardMetadata from "../fixtures/clipboard-metadata.json" with { type: "json" };
@@ -112,6 +113,27 @@ describe("search tool", () => {
     assert.ok(text.includes("502"), "response includes error code");
     assert.ok(text.includes(query), "response includes query");
     assert.ok(text.includes("try again"), "response suggests next action");
+  });
+
+  it("should gracefully handle blocked request", async () => {
+    const query = "malicious_payload";
+    mockPool
+      .intercept({
+        path: `/api/v1/search?q=${query}`,
+        method: "GET",
+      })
+      .reply(406);
+
+    /** @type {any} */
+    const { content } = await client.callTool({
+      name: "search",
+      arguments: {
+        query,
+      },
+    });
+    /** @type {string} */
+    const text = content[0].text;
+    assert.deepEqual(text, `Error: We couldn't search for "${query}"`);
   });
 
   it("should include single compat key", async () => {
@@ -223,6 +245,30 @@ describe("search tool", () => {
       assert.equal(record.mock.calls.length, 1);
       assert.deepEqual(record.mock.calls[0]?.arguments[0], {
         result_count: 0,
+        user_agent: "node",
+      });
+    });
+
+    it("should send error for blocked request", async () => {
+      const record = mock.method(silentError, "record");
+      const query = "malicious_payload";
+
+      mockPool
+        .intercept({
+          path: `/api/v1/search?q=${query}`,
+          method: "GET",
+        })
+        .reply(406);
+
+      await client.callTool({
+        name: "search",
+        arguments: { query },
+      });
+
+      assert.equal(record.mock.calls.length, 1);
+      assert.deepEqual(record.mock.calls[0]?.arguments[0], {
+        tool: "search",
+        reason: "406",
         user_agent: "node",
       });
     });

--- a/tools/get-compat.js
+++ b/tools/get-compat.js
@@ -43,6 +43,13 @@ export function registerGetCompatTool(server) {
             "404",
           );
         }
+        if (res.status === 406) {
+          // fastly waf returns 406 when it blocks a request
+          throw new NonSentryError(
+            `Error: We couldn't fetch "${key}" from the Browser Compatibility Data.`,
+            "406",
+          );
+        }
         throw new Error(`Error: ${res.status}: ${res.statusText}`);
       }
 

--- a/tools/get-doc.js
+++ b/tools/get-doc.js
@@ -95,6 +95,10 @@ export function registerGetDocTool(server) {
           if (res.status === 404) {
             throw new NonSentryError(`Error: We couldn't find ${path}`, "404");
           }
+          if (res.status === 406) {
+            // fastly waf returns 406 when it blocks a request
+            throw new NonSentryError(`Error: We couldn't fetch ${path}`, "406");
+          }
           throw new Error(`${res.status}: ${res.statusText} for ${path}`);
         }
 

--- a/tools/search.js
+++ b/tools/search.js
@@ -2,6 +2,7 @@ import z from "zod";
 
 import { completed } from "../glean/generated/search.js";
 import { submitEvent } from "../glean/glean.js";
+import { NonSentryError } from "../sentry/error.js";
 
 /**
  * @import { SearchResponse, SearchDocument } from "@mdn/fred/components/site-search/types.js";
@@ -33,6 +34,13 @@ export function registerSearchTool(server) {
 
       const res = await fetch(url);
       if (!res.ok) {
+        if (res.status === 406) {
+          // fastly waf returns 406 when it blocks a request
+          throw new NonSentryError(
+            `Error: We couldn't search for "${query}"`,
+            "406",
+          );
+        }
         throw new Error(
           `${res.status}: ${res.statusText} for "${query}", perhaps try again.`,
         );


### PR DESCRIPTION
Our Fastly WAF returns 406 for blocked requests - this isn't an issue with the MCP, so we shouldn't surface them to Sentry.

e.g. https://mozilla.sentry.io/issues/7572628649
