### PR TITLE
chore(deps-dev): pin undici to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "prettier": "^3.9.6",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.67.0",
-        "undici": "^8.0.2",
+        "undici": "8.0.2",
         "zod": "^4.4.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prettier": "^3.9.6",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.67.0",
-    "undici": "^8.0.2",
+    "undici": "8.0.2",
     "zod": "^4.4.3"
   }
 }


### PR DESCRIPTION
Unblocks https://github.com/mdn/mcp/pull/236 - that PR bumps undici to a version which still breaks our fetch-based tests. Pinning undici should mean that doesn't happen

https://github.com/nodejs/undici/pull/5648 fixes the undici bug but isn't released yet: dependabot should still update after release, even with a pinned version.