### PR TITLE
build(npm): allowlist + enforce dependency install scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+strict-allow-scripts=true

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": ">=11.8.0"
+      "version": ">=11.16.0"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -56,5 +56,12 @@
     "typescript-eslint": "^8.69.0",
     "undici": "8.0.2",
     "zod": "^4.5.4"
+  },
+  "allowScripts": {
+    "@mdn/rari": true,
+    "@modelcontextprotocol/inspector": true,
+    "fsevents": true,
+    "lefthook": true,
+    "unrs-resolver": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "allowScripts": {
     "@mdn/rari": true,
     "@modelcontextprotocol/inspector": true,
-    "fsevents": true,
+    "fsevents": false,
     "lefthook": true,
     "unrs-resolver": true
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "allowScripts": {
     "@mdn/rari": true,
-    "@modelcontextprotocol/inspector": true,
+    "@modelcontextprotocol/inspector": false,
     "fsevents": false,
     "lefthook": true,
     "unrs-resolver": true


### PR DESCRIPTION
### Description

Add an `allowScripts` allowlist for the dependencies with install scripts, deny the two that do nothing useful here, enable `strict-allow-scripts`, and require npm 11.16+ in `devEngines`.

### Motivation

npm 12 no longer runs dependency `preinstall`/`install`/`postinstall` scripts unless the root `package.json` allowlists them, and `npm ci` still exits 0, so the failure only shows up later as a missing binary. Without the allowlist, `@mdn/rari` (via `@mdn/fred`) never fetches its binary and `lefthook` never registers its git hooks.

### Additional details

- Entries are name-only (`--no-allow-scripts-pin`), so Dependabot bumps do not need re-approval commits, at the cost of trusting future versions of the listed packages.
- `fsevents` is denied (`false`): its tarball ships a prebuilt binary and has no `install` script, only the registry manifest lists one.
- `@modelcontextprotocol/inspector` is denied: its `postinstall` exits immediately when installed under `node_modules`.
- `unrs-resolver` stays allowed: its `postinstall` is a fallback that only does work when the platform-specific optional binding failed to install.
- `strict-allow-scripts=true` in `.npmrc` turns an uncovered install script into a hard `npm ci` error (honored by npm 11.16+, not only npm 12).
- `devEngines` npm floor raised from 11.8.0 to 11.16.0, the first version that understands `allowScripts`.
- Verified: `npm ci --strict-allow-scripts` passes on npm 12.0.2 and 11.19.0; `npm approve-scripts --allow-scripts-pending` reports nothing.

### Related issues and pull requests

Part of mdn/fred#1868.
